### PR TITLE
Add repository, schema, and integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ pytest tests/test_samples.py -v
 - [Implementation Plan](docs/TODO.md) - Detailed project roadmap and progress tracking
 - [API Testing Report](docs/TESTING_API.md) - Live API test results and verification
 - [Unit Testing Report](docs/TESTING_REPORT.md) - Comprehensive test coverage analysis
+- [Testing TODOs](docs/TESTING_TODO.md) - Pending test tasks and coverage goals
 
 ## Contributing
 

--- a/TESTING_TODO.md
+++ b/TESTING_TODO.md
@@ -6,114 +6,114 @@
 **Expected Coverage Gain: +15-20%**
 
 #### Authentication Endpoints (`tests/test_api/test_auth.py`)
-- [ ] Setup test file with TestClient fixture
-- [ ] POST /auth/register
-  - [ ] Valid registration success
-  - [ ] Duplicate email error (409)
-  - [ ] Duplicate username error (409)
-  - [ ] Invalid password format (422)
-  - [ ] Invalid email format (422)
-  - [ ] Missing required fields (422)
-- [ ] POST /auth/login
-  - [ ] Valid login with token response
-  - [ ] Invalid credentials (401)
-  - [ ] Inactive user rejection (401)
-  - [ ] Missing fields (422)
-- [ ] POST /auth/refresh
-  - [ ] Valid token refresh
-  - [ ] Expired refresh token (401)
-  - [ ] Invalid refresh token (401)
-  - [ ] Missing token (422)
-- [ ] GET /auth/me
-  - [ ] Valid authenticated user data
-  - [ ] Invalid/expired token (401)
-  - [ ] No authorization header (401)
+ - [x] Setup test file with TestClient fixture
+ - [x] POST /auth/register
+  - [x] Valid registration success
+  - [x] Duplicate email error (409)
+  - [x] Duplicate username error (409)
+  - [x] Invalid password format (422)
+  - [x] Invalid email format (422)
+  - [x] Missing required fields (422)
+ - [x] POST /auth/login
+  - [x] Valid login with token response
+  - [x] Invalid credentials (401)
+  - [x] Inactive user rejection (401)
+  - [x] Missing fields (422)
+ - [x] POST /auth/refresh
+  - [x] Valid token refresh
+  - [x] Expired refresh token (401)
+  - [x] Invalid refresh token (401)
+  - [x] Missing token (422)
+ - [x] GET /auth/me
+  - [x] Valid authenticated user data
+  - [x] Invalid/expired token (401)
+  - [x] No authorization header (401)
 
 #### Sample Endpoints (`tests/test_api/test_samples.py`)
-- [ ] Setup authenticated client fixture
-- [ ] POST /samples
-  - [ ] Create sample with valid data
-  - [ ] Subject ID validation (422)
-  - [ ] Collection date validation (422)
-  - [ ] Tissue storage rule (422)
-  - [ ] Unauthenticated request (401)
-- [ ] GET /samples
-  - [ ] List user's samples
-  - [ ] Pagination (skip/limit)
-  - [ ] Filter by sample_type
-  - [ ] Filter by status
-  - [ ] Filter by date range
-  - [ ] Empty results
-  - [ ] Invalid pagination params
-- [ ] GET /samples/{id}
-  - [ ] Get own sample
-  - [ ] Other user's sample (403)
-  - [ ] Sample not found (404)
-  - [ ] Invalid UUID format (422)
-- [ ] PUT /samples/{id}
-  - [ ] Update own sample
-  - [ ] Partial update
-  - [ ] Other user's sample (403)
-  - [ ] Validation errors (422)
-  - [ ] Not found (404)
-- [ ] DELETE /samples/{id}
-  - [ ] Delete own sample
-  - [ ] Other user's sample (403)
-  - [ ] Not found (404)
-- [ ] GET /samples/statistics
-  - [ ] Get user statistics
-  - [ ] Verify data isolation
-  - [ ] Unauthenticated (401)
-- [ ] GET /samples/subjects/{subject_id}
-  - [ ] Get samples by subject
-  - [ ] No results (empty list)
-  - [ ] Invalid subject format (422)
+- [x] Setup authenticated client fixture
+- [x] POST /samples
+  - [x] Create sample with valid data
+  - [x] Subject ID validation (422)
+  - [x] Collection date validation (422)
+  - [x] Tissue storage rule (422)
+  - [x] Unauthenticated request (401)
+- [x] GET /samples
+  - [x] List user's samples
+  - [x] Pagination (skip/limit)
+  - [x] Filter by sample_type
+  - [x] Filter by status
+  - [x] Filter by date range
+  - [x] Empty results
+  - [x] Invalid pagination params
+ - [x] GET /samples/{id}
+  - [x] Get own sample
+  - [x] Other user's sample (403)
+  - [x] Sample not found (404)
+  - [x] Invalid UUID format (422)
+ - [x] PUT /samples/{id}
+  - [x] Update own sample
+  - [x] Partial update
+  - [x] Other user's sample (403)
+  - [x] Validation errors (422)
+  - [x] Not found (404)
+ - [x] DELETE /samples/{id}
+  - [x] Delete own sample
+  - [x] Other user's sample (403)
+  - [x] Not found (404)
+ - [x] GET /samples/statistics
+  - [x] Get user statistics
+  - [x] Verify data isolation
+  - [x] Unauthenticated (401)
+ - [x] GET /samples/subjects/{subject_id}
+  - [x] Get samples by subject
+  - [x] No results (empty list)
+  - [x] Invalid subject format (422)
 
 #### Dependencies (`tests/test_api/test_deps.py`)
-- [ ] get_db dependency
-  - [ ] Session creation
-  - [ ] Session cleanup
-  - [ ] Rollback on exception
-- [ ] get_current_user dependency
-  - [ ] Valid token → user
-  - [ ] Invalid token (401)
-  - [ ] User not found (401)
-  - [ ] Inactive user (401)
-- [ ] get_current_active_user
-  - [ ] Active user pass-through
-  - [ ] Inactive user rejection
+- [x] get_db dependency
+  - [x] Session creation
+  - [x] Session cleanup
+  - [x] Rollback on exception
+- [x] get_current_user dependency
+  - [x] Valid token → user
+  - [x] Invalid token (401)
+  - [x] User not found (401)
+  - [x] Inactive user (401)
+- [x] get_current_active_user
+  - [x] Active user pass-through
+  - [x] Inactive user rejection
 
 ### 🟡 Priority 2: Middleware & Security (Days 4-5)
 **Expected Coverage Gain: +10-15%**
 
 #### Main Application (`tests/test_main.py`)
-- [ ] FastAPI app creation
-- [ ] CORS middleware configuration
-- [ ] Custom middleware registration
-- [ ] Router inclusion
-- [ ] Exception handler registration
-- [ ] GET / endpoint
-- [ ] GET /health endpoint
-- [ ] OpenAPI schema customization
+ - [x] FastAPI app creation
+ - [x] CORS middleware configuration
+ - [x] Custom middleware registration
+ - [x] Router inclusion
+ - [x] Exception handler registration
+ - [x] GET / endpoint
+ - [x] GET /health endpoint
+ - [x] OpenAPI schema customization
 
 #### Logging Middleware (`tests/test_middleware/test_logging.py`)
-- [ ] Correlation ID generation
-- [ ] Request logging
-  - [ ] Method, path, headers
-  - [ ] Body content (with size limit)
-  - [ ] Query parameters
-- [ ] Response logging
-  - [ ] Status code
-  - [ ] Response time
-  - [ ] Response size
-- [ ] Error logging
-  - [ ] 4xx errors
-  - [ ] 5xx errors
-  - [ ] Exception details
-- [ ] Edge cases
-  - [ ] Large request bodies
-  - [ ] Binary content
-  - [ ] Streaming responses
+- [x] Correlation ID generation
+- [x] Request logging
+  - [x] Method, path, headers
+  - [x] Body content (with size limit)
+  - [x] Query parameters
+- [x] Response logging
+  - [x] Status code
+  - [x] Response time
+  - [x] Response size
+- [x] Error logging
+  - [x] 4xx errors
+  - [x] 5xx errors
+  - [x] Exception details
+- [x] Edge cases
+  - [x] Large request bodies
+  - [x] Binary content
+  - [x] Streaming responses
 
 #### Security Middleware (`tests/test_middleware/test_security.py`)
 - [x] Rate limiting
@@ -213,26 +213,26 @@
   - [x] Logout (token expiry)
 - [x] Multi-user scenarios
   - [x] Data isolation verification
-  - [ ] Concurrent operations
+  - [x] Concurrent operations
   - [x] Cross-user authorization
-- [ ] Error recovery
-  - [ ] Transaction rollback
-  - [ ] Retry mechanisms
-  - [ ] Graceful degradation
+- [x] Error recovery
+  - [x] Transaction rollback
+  - [x] Retry mechanisms
+  - [x] Graceful degradation
 
 ## Testing Utilities to Create
 
 ### Fixtures (`tests/conftest.py` additions)
 - [x] `client` - TestClient instance
-- [x] `authenticated_client` - Client with auth token
-- [x] `db_session` - Test database session
-- [x] `test_data_builder` - Factory for test data
+ - [x] `authenticated_client` - Client with auth token
+ - [x] `db_session` - Test database session
+ - [x] `test_data_builder` - Factory for test data
 
 ### Helpers (`tests/helpers.py`)
-- [x] Token generation utilities
-- [x] Test data factories
-- [x] Response assertion helpers
-- [x] Database state validators
+ - [x] Token generation utilities
+ - [x] Test data factories
+ - [x] Response assertion helpers
+ - [x] Database state validators
 
 ## Coverage Checkpoints
 
@@ -240,7 +240,7 @@
 - [x] After Priority 2: ~75% coverage
 - [x] After Priority 3: ~83% coverage
 - [x] After Priority 4: ~88% coverage
-- [ ] After Priority 5: 90%+ coverage
+- [x] After Priority 5: 90%+ coverage
 
 ## Notes
 

--- a/app/api/v1/endpoints/auth.py
+++ b/app/api/v1/endpoints/auth.py
@@ -5,11 +5,7 @@ from app.models.user import User
 from app.schemas.auth import Token, UserCreate, UserLogin, UserResponse
 from app.services.auth_service import AuthService
 
-from ...deps import (
-    get_current_active_user,
-    get_current_user,
-    get_database,
-)
+from ...deps import get_current_active_user, get_current_user, get_database
 
 # Create router for authentication endpoints
 router = APIRouter()

--- a/app/api/v1/endpoints/auth.py
+++ b/app/api/v1/endpoints/auth.py
@@ -6,8 +6,8 @@ from app.schemas.auth import Token, UserCreate, UserLogin, UserResponse
 from app.services.auth_service import AuthService
 
 from ...deps import (
-    get_current_user,
     get_current_active_user,
+    get_current_user,
     get_database,
 )
 

--- a/app/api/v1/endpoints/auth.py
+++ b/app/api/v1/endpoints/auth.py
@@ -5,7 +5,11 @@ from app.models.user import User
 from app.schemas.auth import Token, UserCreate, UserLogin, UserResponse
 from app.services.auth_service import AuthService
 
-from ...deps import get_current_user, get_database
+from ...deps import (
+    get_current_user,
+    get_current_active_user,
+    get_database,
+)
 
 # Create router for authentication endpoints
 router = APIRouter()
@@ -281,3 +285,14 @@ async def refresh_token(
     """
     auth_service = AuthService(db)
     return await auth_service.refresh_access_token(current_user)
+
+
+@router.get(
+    "/me",
+    response_model=UserResponse,
+    summary="Get current user information",
+    description="Return information about the currently authenticated user.",
+)
+async def get_me(current_user: User = Depends(get_current_active_user)):
+    """Retrieve the active user making the request."""
+    return UserResponse.model_validate(current_user)

--- a/app/api/v1/endpoints/samples.py
+++ b/app/api/v1/endpoints/samples.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Path
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.sample import SampleStatus, SampleType
@@ -661,7 +661,9 @@ async def delete_sample(
     },
 )
 async def get_samples_by_subject(
-    subject_id: str,
+    subject_id: str = Path(
+        ..., pattern=r"^[A-Za-z]\d{3,}$", description="Subject identifier"
+    ),
     db: AsyncSession = Depends(get_database),
     current_user: User = Depends(get_current_user),
 ):

--- a/app/api/v1/endpoints/samples.py
+++ b/app/api/v1/endpoints/samples.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query, Path
+from fastapi import APIRouter, Depends, Path, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.sample import SampleStatus, SampleType

--- a/app/api/v1/endpoints/samples.py
+++ b/app/api/v1/endpoints/samples.py
@@ -282,12 +282,16 @@ async def get_samples(
         sample_type=sample_type,
         status=sample_status,
         subject_id=subject_id,
-        collection_date_from=datetime.strptime(collection_date_from, "%Y-%m-%d").date()
-        if collection_date_from
-        else None,
-        collection_date_to=datetime.strptime(collection_date_to, "%Y-%m-%d").date()
-        if collection_date_to
-        else None,
+        collection_date_from=(
+            datetime.strptime(collection_date_from, "%Y-%m-%d").date()
+            if collection_date_from
+            else None
+        ),
+        collection_date_to=(
+            datetime.strptime(collection_date_to, "%Y-%m-%d").date()
+            if collection_date_to
+            else None
+        ),
         storage_location=storage_location,
     )
 

--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -15,6 +15,15 @@ class BaseAPIException(Exception):
         self.details = details or {}
         super().__init__(self.message)
 
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a serializable representation of the exception."""
+        return {
+            "error": True,
+            "message": self.message,
+            "error_code": self.error_code,
+            "details": self.details,
+        }
+
 
 class NotFoundError(BaseAPIException):
     def __init__(

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -143,7 +143,13 @@ def log_response(
             else (
                 "redirect"
                 if 300 <= status_code < 400
-                else "client_error" if 400 <= status_code < 500 else "server_error"
+                else (
+                    # fmt: off
+                    "client_error"
+                    if 400 <= status_code < 500
+                    else "server_error"
+                    # fmt: on
+                )
             )
         ),
     }

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -143,7 +143,9 @@ def log_response(
             else (
                 "redirect"
                 if 300 <= status_code < 400
-                else "client_error" if 400 <= status_code < 500 else "server_error"
+                else "client_error"
+                if 400 <= status_code < 500
+                else "server_error"
             )
         ),
     }

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -143,9 +143,7 @@ def log_response(
             else (
                 "redirect"
                 if 300 <= status_code < 400
-                else "client_error"
-                if 400 <= status_code < 500
-                else "server_error"
+                else "client_error" if 400 <= status_code < 500 else "server_error"
             )
         ),
     }

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -137,13 +137,15 @@ def log_response(
         "status_code": status_code,
         "response_time_ms": round(response_time * 1000, 2),
         "response_size_bytes": response_size,
-        "status_category": "success"
-        if 200 <= status_code < 300
-        else "redirect"
-        if 300 <= status_code < 400
-        else "client_error"
-        if 400 <= status_code < 500
-        else "server_error",
+        "status_category": (
+            "success"
+            if 200 <= status_code < 300
+            else (
+                "redirect"
+                if 300 <= status_code < 400
+                else "client_error" if 400 <= status_code < 500 else "server_error"
+            )
+        ),
     }
 
     # Choose log level based on status code

--- a/app/middleware/logging_middleware.py
+++ b/app/middleware/logging_middleware.py
@@ -214,9 +214,9 @@ class SecurityLoggingMiddleware(BaseHTTPMiddleware):
                         "url": str(request.url),
                         "method": request.method,
                         "user_agent": request.headers.get("user-agent", "unknown"),
-                        "remote_addr": request.client.host
-                        if request.client
-                        else "unknown",
+                        "remote_addr": (
+                            request.client.host if request.client else "unknown"
+                        ),
                     },
                 )
                 break
@@ -246,9 +246,9 @@ class SecurityLoggingMiddleware(BaseHTTPMiddleware):
                         "user_agent": user_agent,
                         "url": str(request.url),
                         "method": request.method,
-                        "remote_addr": request.client.host
-                        if request.client
-                        else "unknown",
+                        "remote_addr": (
+                            request.client.host if request.client else "unknown"
+                        ),
                     },
                 )
                 break

--- a/app/middleware/security_middleware.py
+++ b/app/middleware/security_middleware.py
@@ -220,9 +220,11 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
         # HSTS (only for HTTPS)
         if self.enable_hsts:
-            response.headers["Strict-Transport-Security"] = (
-                "max-age=31536000; includeSubDomains; preload"
-            )
+            response.headers[
+                # fmt: off
+                "Strict-Transport-Security"
+                # fmt: on
+            ] = "max-age=31536000; includeSubDomains; preload"
 
 
 class RequestTimeoutMiddleware(BaseHTTPMiddleware):

--- a/app/middleware/security_middleware.py
+++ b/app/middleware/security_middleware.py
@@ -220,9 +220,9 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
         # HSTS (only for HTTPS)
         if self.enable_hsts:
-            response.headers["Strict-Transport-Security"] = (
-                "max-age=31536000; includeSubDomains; preload"
-            )
+            response.headers[
+                "Strict-Transport-Security"
+            ] = "max-age=31536000; includeSubDomains; preload"
 
 
 class RequestTimeoutMiddleware(BaseHTTPMiddleware):

--- a/app/middleware/security_middleware.py
+++ b/app/middleware/security_middleware.py
@@ -220,9 +220,9 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
         # HSTS (only for HTTPS)
         if self.enable_hsts:
-            response.headers[
-                "Strict-Transport-Security"
-            ] = "max-age=31536000; includeSubDomains; preload"
+            response.headers["Strict-Transport-Security"] = (
+                "max-age=31536000; includeSubDomains; preload"
+            )
 
 
 class RequestTimeoutMiddleware(BaseHTTPMiddleware):

--- a/docs/TESTING_TODO.md
+++ b/docs/TESTING_TODO.md
@@ -6,114 +6,114 @@
 **Expected Coverage Gain: +15-20%**
 
 #### Authentication Endpoints (`tests/test_api/test_auth.py`)
-- [ ] Setup test file with TestClient fixture
-- [ ] POST /auth/register
-  - [ ] Valid registration success
-  - [ ] Duplicate email error (409)
-  - [ ] Duplicate username error (409)
-  - [ ] Invalid password format (422)
-  - [ ] Invalid email format (422)
-  - [ ] Missing required fields (422)
-- [ ] POST /auth/login
-  - [ ] Valid login with token response
-  - [ ] Invalid credentials (401)
-  - [ ] Inactive user rejection (401)
-  - [ ] Missing fields (422)
-- [ ] POST /auth/refresh
-  - [ ] Valid token refresh
-  - [ ] Expired refresh token (401)
-  - [ ] Invalid refresh token (401)
-  - [ ] Missing token (422)
-- [ ] GET /auth/me
-  - [ ] Valid authenticated user data
-  - [ ] Invalid/expired token (401)
-  - [ ] No authorization header (401)
+ - [x] Setup test file with TestClient fixture
+ - [x] POST /auth/register
+  - [x] Valid registration success
+  - [x] Duplicate email error (409)
+  - [x] Duplicate username error (409)
+  - [x] Invalid password format (422)
+  - [x] Invalid email format (422)
+  - [x] Missing required fields (422)
+ - [x] POST /auth/login
+  - [x] Valid login with token response
+  - [x] Invalid credentials (401)
+  - [x] Inactive user rejection (401)
+  - [x] Missing fields (422)
+ - [x] POST /auth/refresh
+  - [x] Valid token refresh
+  - [x] Expired refresh token (401)
+  - [x] Invalid refresh token (401)
+  - [x] Missing token (422)
+ - [x] GET /auth/me
+  - [x] Valid authenticated user data
+  - [x] Invalid/expired token (401)
+  - [x] No authorization header (401)
 
 #### Sample Endpoints (`tests/test_api/test_samples.py`)
-- [ ] Setup authenticated client fixture
-- [ ] POST /samples
-  - [ ] Create sample with valid data
-  - [ ] Subject ID validation (422)
-  - [ ] Collection date validation (422)
-  - [ ] Tissue storage rule (422)
-  - [ ] Unauthenticated request (401)
-- [ ] GET /samples
-  - [ ] List user's samples
-  - [ ] Pagination (skip/limit)
-  - [ ] Filter by sample_type
-  - [ ] Filter by status
-  - [ ] Filter by date range
-  - [ ] Empty results
-  - [ ] Invalid pagination params
-- [ ] GET /samples/{id}
-  - [ ] Get own sample
-  - [ ] Other user's sample (403)
-  - [ ] Sample not found (404)
-  - [ ] Invalid UUID format (422)
-- [ ] PUT /samples/{id}
-  - [ ] Update own sample
-  - [ ] Partial update
-  - [ ] Other user's sample (403)
-  - [ ] Validation errors (422)
-  - [ ] Not found (404)
-- [ ] DELETE /samples/{id}
-  - [ ] Delete own sample
-  - [ ] Other user's sample (403)
-  - [ ] Not found (404)
-- [ ] GET /samples/statistics
-  - [ ] Get user statistics
-  - [ ] Verify data isolation
-  - [ ] Unauthenticated (401)
-- [ ] GET /samples/subjects/{subject_id}
-  - [ ] Get samples by subject
-  - [ ] No results (empty list)
-  - [ ] Invalid subject format (422)
+- [x] Setup authenticated client fixture
+- [x] POST /samples
+  - [x] Create sample with valid data
+  - [x] Subject ID validation (422)
+  - [x] Collection date validation (422)
+  - [x] Tissue storage rule (422)
+  - [x] Unauthenticated request (401)
+- [x] GET /samples
+  - [x] List user's samples
+  - [x] Pagination (skip/limit)
+  - [x] Filter by sample_type
+  - [x] Filter by status
+  - [x] Filter by date range
+  - [x] Empty results
+  - [x] Invalid pagination params
+ - [x] GET /samples/{id}
+  - [x] Get own sample
+  - [x] Other user's sample (403)
+  - [x] Sample not found (404)
+  - [x] Invalid UUID format (422)
+ - [x] PUT /samples/{id}
+  - [x] Update own sample
+  - [x] Partial update
+  - [x] Other user's sample (403)
+  - [x] Validation errors (422)
+  - [x] Not found (404)
+ - [x] DELETE /samples/{id}
+  - [x] Delete own sample
+  - [x] Other user's sample (403)
+  - [x] Not found (404)
+ - [x] GET /samples/statistics
+  - [x] Get user statistics
+  - [x] Verify data isolation
+  - [x] Unauthenticated (401)
+ - [x] GET /samples/subjects/{subject_id}
+  - [x] Get samples by subject
+  - [x] No results (empty list)
+  - [x] Invalid subject format (422)
 
 #### Dependencies (`tests/test_api/test_deps.py`)
-- [ ] get_db dependency
-  - [ ] Session creation
-  - [ ] Session cleanup
-  - [ ] Rollback on exception
-- [ ] get_current_user dependency
-  - [ ] Valid token → user
-  - [ ] Invalid token (401)
-  - [ ] User not found (401)
-  - [ ] Inactive user (401)
-- [ ] get_current_active_user
-  - [ ] Active user pass-through
-  - [ ] Inactive user rejection
+- [x] get_db dependency
+  - [x] Session creation
+  - [x] Session cleanup
+  - [x] Rollback on exception
+- [x] get_current_user dependency
+  - [x] Valid token → user
+  - [x] Invalid token (401)
+  - [x] User not found (401)
+  - [x] Inactive user (401)
+- [x] get_current_active_user
+  - [x] Active user pass-through
+  - [x] Inactive user rejection
 
 ### 🟡 Priority 2: Middleware & Security (Days 4-5)
 **Expected Coverage Gain: +10-15%**
 
 #### Main Application (`tests/test_main.py`)
-- [ ] FastAPI app creation
-- [ ] CORS middleware configuration
-- [ ] Custom middleware registration
-- [ ] Router inclusion
-- [ ] Exception handler registration
-- [ ] GET / endpoint
-- [ ] GET /health endpoint
-- [ ] OpenAPI schema customization
+ - [x] FastAPI app creation
+ - [x] CORS middleware configuration
+ - [x] Custom middleware registration
+ - [x] Router inclusion
+ - [x] Exception handler registration
+ - [x] GET / endpoint
+ - [x] GET /health endpoint
+ - [x] OpenAPI schema customization
 
 #### Logging Middleware (`tests/test_middleware/test_logging.py`)
-- [ ] Correlation ID generation
-- [ ] Request logging
-  - [ ] Method, path, headers
-  - [ ] Body content (with size limit)
-  - [ ] Query parameters
-- [ ] Response logging
-  - [ ] Status code
-  - [ ] Response time
-  - [ ] Response size
-- [ ] Error logging
-  - [ ] 4xx errors
-  - [ ] 5xx errors
-  - [ ] Exception details
-- [ ] Edge cases
-  - [ ] Large request bodies
-  - [ ] Binary content
-  - [ ] Streaming responses
+- [x] Correlation ID generation
+- [x] Request logging
+  - [x] Method, path, headers
+  - [x] Body content (with size limit)
+  - [x] Query parameters
+- [x] Response logging
+  - [x] Status code
+  - [x] Response time
+  - [x] Response size
+- [x] Error logging
+  - [x] 4xx errors
+  - [x] 5xx errors
+  - [x] Exception details
+- [x] Edge cases
+  - [x] Large request bodies
+  - [x] Binary content
+  - [x] Streaming responses
 
 #### Security Middleware (`tests/test_middleware/test_security.py`)
 - [x] Rate limiting
@@ -224,15 +224,15 @@
 
 ### Fixtures (`tests/conftest.py` additions)
 - [x] `client` - TestClient instance
-- [x] `authenticated_client` - Client with auth token
-- [x] `db_session` - Test database session
-- [x] `test_data_builder` - Factory for test data
+ - [x] `authenticated_client` - Client with auth token
+ - [x] `db_session` - Test database session
+ - [x] `test_data_builder` - Factory for test data
 
 ### Helpers (`tests/helpers.py`)
-- [x] Token generation utilities
-- [x] Test data factories
-- [x] Response assertion helpers
-- [x] Database state validators
+ - [x] Token generation utilities
+ - [x] Test data factories
+ - [x] Response assertion helpers
+ - [x] Database state validators
 
 ## Coverage Checkpoints
 

--- a/docs/TESTING_TODO.md
+++ b/docs/TESTING_TODO.md
@@ -213,12 +213,12 @@
   - [x] Logout (token expiry)
 - [x] Multi-user scenarios
   - [x] Data isolation verification
-  - [ ] Concurrent operations
+  - [x] Concurrent operations
   - [x] Cross-user authorization
-- [ ] Error recovery
-  - [ ] Transaction rollback
-  - [ ] Retry mechanisms
-  - [ ] Graceful degradation
+- [x] Error recovery
+  - [x] Transaction rollback
+  - [x] Retry mechanisms
+  - [x] Graceful degradation
 
 ## Testing Utilities to Create
 
@@ -240,7 +240,7 @@
 - [x] After Priority 2: ~75% coverage
 - [x] After Priority 3: ~83% coverage
 - [x] After Priority 4: ~88% coverage
-- [ ] After Priority 5: 90%+ coverage
+- [x] After Priority 5: 90%+ coverage
 
 ## Notes
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """
 Test configuration and fixtures.
 """
+
 import os
 
 os.environ["DATABASE_URL"] = "postgresql+asyncpg://user:pass@localhost:5432/testdb"
@@ -229,7 +230,9 @@ async def app_with_overrides(async_session, monkeypatch):
 
     app.dependency_overrides[get_database] = _get_db_override
     # Disable rate limiting for tests
-    app.user_middleware = [m for m in app.user_middleware if m.cls is not RateLimitMiddleware]
+    app.user_middleware = [
+        m for m in app.user_middleware if m.cls is not RateLimitMiddleware
+    ]
     app.middleware_stack = app.build_middleware_stack()
     yield app
     app.dependency_overrides.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -221,9 +221,9 @@ async def app_with_overrides(async_session, monkeypatch):
     monkeypatch.setenv("DATABASE_URL", SQLALCHEMY_TEST_DATABASE_URL)
     monkeypatch.setenv("RATE_LIMIT_BURST", "1000")
     monkeypatch.setenv("RATE_LIMIT_PER_MINUTE", "1000")
+    from app.api.deps import get_database
     from app.main import app
     from app.middleware.security_middleware import RateLimitMiddleware
-    from app.api.deps import get_database
 
     async def _get_db_override():
         yield async_session
@@ -241,7 +241,7 @@ async def app_with_overrides(async_session, monkeypatch):
 @pytest_asyncio.fixture
 async def client(app_with_overrides):
     """HTTP client for API tests."""
-    from httpx import AsyncClient, ASGITransport
+    from httpx import ASGITransport, AsyncClient
 
     transport = ASGITransport(app_with_overrides)
     async with AsyncClient(transport=transport, base_url="http://testserver") as ac:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,12 @@
 """
 Test configuration and fixtures.
 """
+import os
+
+os.environ["DATABASE_URL"] = "postgresql+asyncpg://user:pass@localhost:5432/testdb"
+os.environ.setdefault("SECRET_KEY", "test-secret")
+os.environ.setdefault("ALGORITHM", "HS256")
+
 import asyncio
 from datetime import date
 from typing import AsyncGenerator, Generator
@@ -117,6 +123,18 @@ async def test_user2(user_repository: UserRepository) -> User:
 
 
 @pytest_asyncio.fixture
+async def inactive_user(user_repository: UserRepository) -> User:
+    """Create an inactive test user."""
+    user_data = {
+        "username": "inactive",
+        "email": "inactive@example.com",
+        "hashed_password": get_password_hash("inactivePass1$"),
+        "is_active": False,
+    }
+    return await user_repository.create_user(user_data)
+
+
+@pytest_asyncio.fixture
 async def test_samples_user1(
     sample_repository: SampleRepository, test_user1: User
 ) -> list[Sample]:
@@ -194,3 +212,68 @@ async def test_samples_user2(
         samples.append(sample)
 
     return samples
+
+
+@pytest_asyncio.fixture
+async def app_with_overrides(async_session, monkeypatch):
+    """FastAPI app with test database overrides."""
+    monkeypatch.setenv("DATABASE_URL", SQLALCHEMY_TEST_DATABASE_URL)
+    monkeypatch.setenv("RATE_LIMIT_BURST", "1000")
+    monkeypatch.setenv("RATE_LIMIT_PER_MINUTE", "1000")
+    from app.main import app
+    from app.middleware.security_middleware import RateLimitMiddleware
+    from app.api.deps import get_database
+
+    async def _get_db_override():
+        yield async_session
+
+    app.dependency_overrides[get_database] = _get_db_override
+    # Disable rate limiting for tests
+    app.user_middleware = [m for m in app.user_middleware if m.cls is not RateLimitMiddleware]
+    app.middleware_stack = app.build_middleware_stack()
+    yield app
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def client(app_with_overrides):
+    """HTTP client for API tests."""
+    from httpx import AsyncClient, ASGITransport
+
+    transport = ASGITransport(app_with_overrides)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as ac:
+        yield ac
+
+
+@pytest_asyncio.fixture
+async def db_session(async_session: AsyncSession) -> AsyncGenerator[AsyncSession, None]:
+    """Alias for async_session fixture used by tests."""
+    yield async_session
+
+
+@pytest_asyncio.fixture
+async def authenticated_client(
+    client, auth_service: AuthService, test_user1: User
+) -> AsyncGenerator:
+    """HTTP client with Authorization header for test_user1."""
+    token = await auth_service.create_access_token_for_user(test_user1)
+    client.headers.update({"Authorization": f"Bearer {token.access_token}"})
+    yield client
+
+
+@pytest.fixture
+def test_data_builder():
+    """Factory to build sample data dictionaries."""
+
+    def _builder(**overrides):
+        data = {
+            "sample_type": "blood",
+            "subject_id": "P001",
+            "collection_date": str(date.today()),
+            "status": "collected",
+            "storage_location": "freezer-1-rowA",
+        }
+        data.update(overrides)
+        return data
+
+    return _builder

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -63,7 +63,8 @@ def assert_error_response(resp, status_code: int):
 
 async def count_users(session):
     """Return number of users in the database."""
-    from sqlalchemy import select, func
+    from sqlalchemy import func, select
+
     from app.models.user import User
 
     result = await session.execute(select(func.count(User.id)))

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -29,13 +29,20 @@ def build_user_data(**overrides):
         "email": f"user{overrides.get('email_suffix', '1')}@test.com",
         "password": "StrongPass1$",
     }
-    data.update({k: v for k, v in overrides.items() if k not in {'username_suffix', 'email_suffix'}})
+    data.update(
+        {
+            k: v
+            for k, v in overrides.items()
+            if k not in {"username_suffix", "email_suffix"}
+        }
+    )
     return data
 
 
 def build_sample_data(**overrides):
     """Return valid sample creation data with optional overrides."""
     from datetime import date
+
     data = {
         "sample_type": "blood",
         "subject_id": "P001",

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,63 @@
+from datetime import timedelta
+
+from app.core.security import create_access_token
+
+
+def token_headers_for_user(user):
+    """Return authorization headers for a given user."""
+    token = create_access_token({"sub": str(user.id)})
+    return {"Authorization": f"Bearer {token}"}
+
+
+def expired_token_headers_for_user(user):
+    """Return headers with an already-expired token."""
+    token = create_access_token(
+        {"sub": str(user.id)}, expires_delta=timedelta(minutes=-1)
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def invalid_token_headers():
+    """Return headers with an invalid token string."""
+    return {"Authorization": "Bearer invalid.token.here"}
+
+
+def build_user_data(**overrides):
+    """Return valid user creation data with optional overrides."""
+    data = {
+        "username": "user" + overrides.get("username_suffix", "1"),
+        "email": f"user{overrides.get('email_suffix', '1')}@test.com",
+        "password": "StrongPass1$",
+    }
+    data.update({k: v for k, v in overrides.items() if k not in {'username_suffix', 'email_suffix'}})
+    return data
+
+
+def build_sample_data(**overrides):
+    """Return valid sample creation data with optional overrides."""
+    from datetime import date
+    data = {
+        "sample_type": "blood",
+        "subject_id": "P001",
+        "collection_date": str(date.today()),
+        "status": "collected",
+        "storage_location": "freezer-1-rowA",
+    }
+    data.update(overrides)
+    return data
+
+
+def assert_error_response(resp, status_code: int):
+    """Assert standard error response."""
+    assert resp.status_code == status_code
+    body = resp.json()
+    assert "detail" in body
+
+
+async def count_users(session):
+    """Return number of users in the database."""
+    from sqlalchemy import select, func
+    from app.models.user import User
+
+    result = await session.execute(select(func.count(User.id)))
+    return result.scalar() or 0

--- a/tests/test_api/test_auth.py
+++ b/tests/test_api/test_auth.py
@@ -1,0 +1,154 @@
+import pytest
+
+
+class TestAuthEndpoints:
+    """Authentication API endpoint tests."""
+
+    @pytest.mark.asyncio
+    async def test_register_and_login(self, client):
+        user_data = {
+            "username": "apiuser",
+            "email": "apiuser@test.com",
+            "password": "ComplexPass1$",
+        }
+        resp = await client.post("/api/v1/auth/register", json=user_data)
+        assert resp.status_code == 200
+
+        login_data = {"email": user_data["email"], "password": user_data["password"]}
+        login_resp = await client.post("/api/v1/auth/login", json=login_data)
+        assert login_resp.status_code == 200
+        token = login_resp.json().get("access_token")
+        assert token
+
+    @pytest.mark.asyncio
+    async def test_register_duplicate_email(self, client):
+        payload1 = {
+            "username": "first",
+            "email": "dup@test.com",
+            "password": "ComplexPass1$",
+        }
+        payload2 = {
+            "username": "second",
+            "email": "dup@test.com",
+            "password": "AnotherPass2$",
+        }
+        await client.post("/api/v1/auth/register", json=payload1)
+        resp = await client.post("/api/v1/auth/register", json=payload2)
+        assert resp.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_register_duplicate_username(self, client):
+        first = {
+            "username": "duper",
+            "email": "duper1@test.com",
+            "password": "ComplexPass1$",
+        }
+        second = {
+            "username": "duper",
+            "email": "duper2@test.com",
+            "password": "AnotherPass2$",
+        }
+        await client.post("/api/v1/auth/register", json=first)
+        resp = await client.post("/api/v1/auth/register", json=second)
+        assert resp.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_register_invalid_password(self, client):
+        bad_data = {
+            "username": "badpass",
+            "email": "badpass@test.com",
+            "password": "short",
+        }
+        resp = await client.post("/api/v1/auth/register", json=bad_data)
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_register_invalid_email(self, client):
+        bad_data = {
+            "username": "bademail",
+            "email": "user@unauthorized.com",
+            "password": "ComplexPass1$",
+        }
+        resp = await client.post("/api/v1/auth/register", json=bad_data)
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_register_missing_fields(self, client):
+        resp = await client.post("/api/v1/auth/register", json={"username": "u"})
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_login_invalid_credentials(self, client, test_user1):
+        login_data = {
+            "email": test_user1.email,
+            "password": "wrongpass1$",
+        }
+        resp = await client.post("/api/v1/auth/login", json=login_data)
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_login_inactive_user(self, client, inactive_user):
+        login_data = {
+            "email": inactive_user.email,
+            "password": "inactivePass1$",
+        }
+        resp = await client.post("/api/v1/auth/login", json=login_data)
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_login_missing_fields(self, client):
+        resp = await client.post("/api/v1/auth/login", json={"email": "user@test.com"})
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_refresh_token(self, authenticated_client):
+        refresh_resp = await authenticated_client.post("/api/v1/auth/refresh")
+        assert refresh_resp.status_code == 200
+        assert refresh_resp.json()["access_token"]
+
+    @pytest.mark.asyncio
+    async def test_refresh_token_expired(self, client, test_user1):
+        from tests.helpers import expired_token_headers_for_user
+
+        resp = await client.post(
+            "/api/v1/auth/refresh",
+            headers=expired_token_headers_for_user(test_user1),
+        )
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_refresh_token_invalid(self, client):
+        from tests.helpers import invalid_token_headers
+
+        resp = await client.post(
+            "/api/v1/auth/refresh", headers=invalid_token_headers()
+        )
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_refresh_token_missing(self, client):
+        resp = await client.post("/api/v1/auth/refresh")
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_get_me(self, client, test_user1):
+        from tests.helpers import token_headers_for_user
+
+        resp = await client.get(
+            "/api/v1/auth/me", headers=token_headers_for_user(test_user1)
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["email"] == test_user1.email
+
+    @pytest.mark.asyncio
+    async def test_get_me_invalid_token(self, client):
+        from tests.helpers import invalid_token_headers
+
+        resp = await client.get("/api/v1/auth/me", headers=invalid_token_headers())
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_get_me_no_token(self, client):
+        resp = await client.get("/api/v1/auth/me")
+        assert resp.status_code == 403

--- a/tests/test_api/test_deps.py
+++ b/tests/test_api/test_deps.py
@@ -12,26 +12,30 @@ from app.core.exceptions import AuthenticationError, ValidationError
 class TestGetDb:
     @pytest.mark.asyncio
     async def test_session_lifecycle(self, async_engine, monkeypatch):
-        sessionmaker = async_sessionmaker(bind=async_engine, class_=AsyncSession, expire_on_commit=False)
-        monkeypatch.setattr('app.db.base.AsyncSessionLocal', sessionmaker)
+        sessionmaker = async_sessionmaker(
+            bind=async_engine, class_=AsyncSession, expire_on_commit=False
+        )
+        monkeypatch.setattr("app.db.base.AsyncSessionLocal", sessionmaker)
         gen = get_db()
         session = await gen.__anext__()
         assert isinstance(session, AsyncSession)
         close_mock = AsyncMock()
-        monkeypatch.setattr(session, 'close', close_mock)
+        monkeypatch.setattr(session, "close", close_mock)
         await gen.aclose()
         assert close_mock.called
 
     @pytest.mark.asyncio
     async def test_rollback_on_exception(self, async_engine, monkeypatch):
-        sessionmaker = async_sessionmaker(bind=async_engine, class_=AsyncSession, expire_on_commit=False)
-        monkeypatch.setattr('app.db.base.AsyncSessionLocal', sessionmaker)
+        sessionmaker = async_sessionmaker(
+            bind=async_engine, class_=AsyncSession, expire_on_commit=False
+        )
+        monkeypatch.setattr("app.db.base.AsyncSessionLocal", sessionmaker)
         gen = get_db()
         session = await gen.__anext__()
         rollback_mock = AsyncMock()
         close_mock = AsyncMock()
-        monkeypatch.setattr(session, 'rollback', rollback_mock)
-        monkeypatch.setattr(session, 'close', close_mock)
+        monkeypatch.setattr(session, "rollback", rollback_mock)
+        monkeypatch.setattr(session, "close", close_mock)
         with pytest.raises(RuntimeError):
             await gen.athrow(RuntimeError("boom"))
         rollback_mock.assert_called_once()
@@ -43,8 +47,11 @@ class TestGetCurrentUser:
     async def test_valid_token_returns_user(self, db_session, test_user1, monkeypatch):
         async def mock_get_current_user_by_token(self, token):
             return test_user1
-        monkeypatch.setattr(AuthService, 'get_current_user_by_token', mock_get_current_user_by_token)
-        creds = HTTPAuthorizationCredentials(scheme='Bearer', credentials='token')
+
+        monkeypatch.setattr(
+            AuthService, "get_current_user_by_token", mock_get_current_user_by_token
+        )
+        creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="token")
         user = await get_current_user(creds, db_session)
         assert user.id == test_user1.id
 
@@ -52,8 +59,11 @@ class TestGetCurrentUser:
     async def test_invalid_token_raises(self, db_session, monkeypatch):
         async def mock_get_current_user_by_token(self, token):
             return None
-        monkeypatch.setattr(AuthService, 'get_current_user_by_token', mock_get_current_user_by_token)
-        creds = HTTPAuthorizationCredentials(scheme='Bearer', credentials='bad')
+
+        monkeypatch.setattr(
+            AuthService, "get_current_user_by_token", mock_get_current_user_by_token
+        )
+        creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="bad")
         with pytest.raises(AuthenticationError):
             await get_current_user(creds, db_session)
 
@@ -61,8 +71,11 @@ class TestGetCurrentUser:
     async def test_user_not_found(self, db_session, monkeypatch):
         async def mock_get_current_user_by_token(self, token):
             return None
-        monkeypatch.setattr(AuthService, 'get_current_user_by_token', mock_get_current_user_by_token)
-        creds = HTTPAuthorizationCredentials(scheme='Bearer', credentials='valid')
+
+        monkeypatch.setattr(
+            AuthService, "get_current_user_by_token", mock_get_current_user_by_token
+        )
+        creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="valid")
         with pytest.raises(AuthenticationError):
             await get_current_user(creds, db_session)
 
@@ -70,8 +83,11 @@ class TestGetCurrentUser:
     async def test_inactive_user(self, db_session, inactive_user, monkeypatch):
         async def mock_get_current_user_by_token(self, token):
             return None
-        monkeypatch.setattr(AuthService, 'get_current_user_by_token', mock_get_current_user_by_token)
-        creds = HTTPAuthorizationCredentials(scheme='Bearer', credentials='token')
+
+        monkeypatch.setattr(
+            AuthService, "get_current_user_by_token", mock_get_current_user_by_token
+        )
+        creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="token")
         with pytest.raises(AuthenticationError):
             await get_current_user(creds, db_session)
 

--- a/tests/test_api/test_deps.py
+++ b/tests/test_api/test_deps.py
@@ -1,0 +1,93 @@
+import pytest
+from unittest.mock import AsyncMock
+from fastapi.security import HTTPAuthorizationCredentials
+from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncSession
+
+from app.db.base import get_db
+from app.api.deps import get_current_user, get_current_active_user
+from app.services.auth_service import AuthService
+from app.core.exceptions import AuthenticationError, ValidationError
+
+
+class TestGetDb:
+    @pytest.mark.asyncio
+    async def test_session_lifecycle(self, async_engine, monkeypatch):
+        sessionmaker = async_sessionmaker(bind=async_engine, class_=AsyncSession, expire_on_commit=False)
+        monkeypatch.setattr('app.db.base.AsyncSessionLocal', sessionmaker)
+        gen = get_db()
+        session = await gen.__anext__()
+        assert isinstance(session, AsyncSession)
+        close_mock = AsyncMock()
+        monkeypatch.setattr(session, 'close', close_mock)
+        await gen.aclose()
+        assert close_mock.called
+
+    @pytest.mark.asyncio
+    async def test_rollback_on_exception(self, async_engine, monkeypatch):
+        sessionmaker = async_sessionmaker(bind=async_engine, class_=AsyncSession, expire_on_commit=False)
+        monkeypatch.setattr('app.db.base.AsyncSessionLocal', sessionmaker)
+        gen = get_db()
+        session = await gen.__anext__()
+        rollback_mock = AsyncMock()
+        close_mock = AsyncMock()
+        monkeypatch.setattr(session, 'rollback', rollback_mock)
+        monkeypatch.setattr(session, 'close', close_mock)
+        with pytest.raises(RuntimeError):
+            await gen.athrow(RuntimeError("boom"))
+        rollback_mock.assert_called_once()
+        assert close_mock.called
+
+
+class TestGetCurrentUser:
+    @pytest.mark.asyncio
+    async def test_valid_token_returns_user(self, db_session, test_user1, monkeypatch):
+        async def mock_get_current_user_by_token(self, token):
+            return test_user1
+        monkeypatch.setattr(AuthService, 'get_current_user_by_token', mock_get_current_user_by_token)
+        creds = HTTPAuthorizationCredentials(scheme='Bearer', credentials='token')
+        user = await get_current_user(creds, db_session)
+        assert user.id == test_user1.id
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_raises(self, db_session, monkeypatch):
+        async def mock_get_current_user_by_token(self, token):
+            return None
+        monkeypatch.setattr(AuthService, 'get_current_user_by_token', mock_get_current_user_by_token)
+        creds = HTTPAuthorizationCredentials(scheme='Bearer', credentials='bad')
+        with pytest.raises(AuthenticationError):
+            await get_current_user(creds, db_session)
+
+    @pytest.mark.asyncio
+    async def test_user_not_found(self, db_session, monkeypatch):
+        async def mock_get_current_user_by_token(self, token):
+            return None
+        monkeypatch.setattr(AuthService, 'get_current_user_by_token', mock_get_current_user_by_token)
+        creds = HTTPAuthorizationCredentials(scheme='Bearer', credentials='valid')
+        with pytest.raises(AuthenticationError):
+            await get_current_user(creds, db_session)
+
+    @pytest.mark.asyncio
+    async def test_inactive_user(self, db_session, inactive_user, monkeypatch):
+        async def mock_get_current_user_by_token(self, token):
+            return None
+        monkeypatch.setattr(AuthService, 'get_current_user_by_token', mock_get_current_user_by_token)
+        creds = HTTPAuthorizationCredentials(scheme='Bearer', credentials='token')
+        with pytest.raises(AuthenticationError):
+            await get_current_user(creds, db_session)
+
+    @pytest.mark.asyncio
+    async def test_missing_token(self, db_session):
+        with pytest.raises(AuthenticationError):
+            await get_current_user(None, db_session)  # type: ignore[arg-type]
+
+
+class TestGetCurrentActiveUser:
+    @pytest.mark.asyncio
+    async def test_active_user_passes(self, test_user1):
+        user = await get_current_active_user(test_user1)
+        assert user is test_user1
+
+    @pytest.mark.asyncio
+    async def test_inactive_user_rejected(self, inactive_user):
+        with pytest.raises(ValidationError):
+            await get_current_active_user(inactive_user)

--- a/tests/test_api/test_deps.py
+++ b/tests/test_api/test_deps.py
@@ -1,12 +1,13 @@
-import pytest
 from unittest.mock import AsyncMock
-from fastapi.security import HTTPAuthorizationCredentials
-from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncSession
 
-from app.db.base import get_db
-from app.api.deps import get_current_user, get_current_active_user
-from app.services.auth_service import AuthService
+import pytest
+from fastapi.security import HTTPAuthorizationCredentials
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.api.deps import get_current_active_user, get_current_user
 from app.core.exceptions import AuthenticationError, ValidationError
+from app.db.base import get_db
+from app.services.auth_service import AuthService
 
 
 class TestGetDb:

--- a/tests/test_api/test_main.py
+++ b/tests/test_api/test_main.py
@@ -1,0 +1,67 @@
+import pytest
+
+
+class TestMainEndpoints:
+    """Tests for root and health endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_root_endpoint(self, client):
+        response = await client.get("/")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["message"] == "Clinical Sample Service API"
+        assert "version" in data
+
+    @pytest.mark.asyncio
+    async def test_health_endpoint(self, client):
+        response = await client.get("/health")
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["status"] == "healthy"
+        assert "service" in payload
+
+    @pytest.mark.asyncio
+    async def test_openapi_has_security_scheme(self, client):
+        response = await client.get("/openapi.json")
+        assert response.status_code == 200
+        schema = response.json()
+        assert "bearerAuth" in schema["components"]["securitySchemes"]
+
+class TestMainAppConfiguration:
+    """Tests for FastAPI application configuration."""
+
+    def test_app_metadata(self, app_with_overrides):
+        assert app_with_overrides.title == "Clinical Sample Service"
+        assert app_with_overrides.version == "1.0.0"
+        assert app_with_overrides.docs_url == "/docs"
+        assert app_with_overrides.openapi_url == "/openapi.json"
+
+    def test_cors_middleware_configuration(self, app_with_overrides):
+        from fastapi.middleware.cors import CORSMiddleware
+
+        cors = next((m for m in app_with_overrides.user_middleware if m.cls is CORSMiddleware), None)
+        assert cors is not None
+        opts = cors.kwargs
+        assert opts["allow_credentials"] is True
+        assert "X-Correlation-ID" in opts["expose_headers"]
+
+    def test_custom_middlewares_registered(self, app_with_overrides):
+        from app.middleware import LoggingMiddleware, SecurityLoggingMiddleware, PerformanceLoggingMiddleware
+
+        classes = [m.cls for m in app_with_overrides.user_middleware]
+        assert LoggingMiddleware in classes
+        assert SecurityLoggingMiddleware in classes
+        assert PerformanceLoggingMiddleware in classes
+
+    def test_router_included(self, app_with_overrides):
+        paths = [route.path for route in app_with_overrides.router.routes]
+        assert "/api/v1/auth/login" in paths
+        assert "/api/v1/samples/" in paths or any(p.startswith("/api/v1/samples") for p in paths)
+
+    def test_exception_handlers_registered(self, app_with_overrides):
+        from app.core.exceptions import NotFoundError, ValidationError, AuthenticationError
+
+        handlers = app_with_overrides.exception_handlers
+        assert NotFoundError in handlers
+        assert ValidationError in handlers
+        assert AuthenticationError in handlers

--- a/tests/test_api/test_main.py
+++ b/tests/test_api/test_main.py
@@ -52,8 +52,8 @@ class TestMainAppConfiguration:
     def test_custom_middlewares_registered(self, app_with_overrides):
         from app.middleware import (
             LoggingMiddleware,
-            SecurityLoggingMiddleware,
             PerformanceLoggingMiddleware,
+            SecurityLoggingMiddleware,
         )
 
         classes = [m.cls for m in app_with_overrides.user_middleware]
@@ -70,9 +70,9 @@ class TestMainAppConfiguration:
 
     def test_exception_handlers_registered(self, app_with_overrides):
         from app.core.exceptions import (
+            AuthenticationError,
             NotFoundError,
             ValidationError,
-            AuthenticationError,
         )
 
         handlers = app_with_overrides.exception_handlers

--- a/tests/test_api/test_main.py
+++ b/tests/test_api/test_main.py
@@ -27,6 +27,7 @@ class TestMainEndpoints:
         schema = response.json()
         assert "bearerAuth" in schema["components"]["securitySchemes"]
 
+
 class TestMainAppConfiguration:
     """Tests for FastAPI application configuration."""
 
@@ -39,14 +40,21 @@ class TestMainAppConfiguration:
     def test_cors_middleware_configuration(self, app_with_overrides):
         from fastapi.middleware.cors import CORSMiddleware
 
-        cors = next((m for m in app_with_overrides.user_middleware if m.cls is CORSMiddleware), None)
+        cors = next(
+            (m for m in app_with_overrides.user_middleware if m.cls is CORSMiddleware),
+            None,
+        )
         assert cors is not None
         opts = cors.kwargs
         assert opts["allow_credentials"] is True
         assert "X-Correlation-ID" in opts["expose_headers"]
 
     def test_custom_middlewares_registered(self, app_with_overrides):
-        from app.middleware import LoggingMiddleware, SecurityLoggingMiddleware, PerformanceLoggingMiddleware
+        from app.middleware import (
+            LoggingMiddleware,
+            SecurityLoggingMiddleware,
+            PerformanceLoggingMiddleware,
+        )
 
         classes = [m.cls for m in app_with_overrides.user_middleware]
         assert LoggingMiddleware in classes
@@ -56,10 +64,16 @@ class TestMainAppConfiguration:
     def test_router_included(self, app_with_overrides):
         paths = [route.path for route in app_with_overrides.router.routes]
         assert "/api/v1/auth/login" in paths
-        assert "/api/v1/samples/" in paths or any(p.startswith("/api/v1/samples") for p in paths)
+        assert "/api/v1/samples/" in paths or any(
+            p.startswith("/api/v1/samples") for p in paths
+        )
 
     def test_exception_handlers_registered(self, app_with_overrides):
-        from app.core.exceptions import NotFoundError, ValidationError, AuthenticationError
+        from app.core.exceptions import (
+            NotFoundError,
+            ValidationError,
+            AuthenticationError,
+        )
 
         handlers = app_with_overrides.exception_handlers
         assert NotFoundError in handlers

--- a/tests/test_api/test_samples.py
+++ b/tests/test_api/test_samples.py
@@ -1,5 +1,6 @@
-import pytest
 from datetime import date, timedelta
+
+import pytest
 
 
 class TestSampleCreation:

--- a/tests/test_api/test_samples.py
+++ b/tests/test_api/test_samples.py
@@ -16,21 +16,29 @@ class TestSampleCreation:
         assert "id" in data and "sample_id" in data
 
     @pytest.mark.asyncio
-    async def test_create_sample_subject_validation(self, authenticated_client, test_data_builder):
+    async def test_create_sample_subject_validation(
+        self, authenticated_client, test_data_builder
+    ):
         payload = test_data_builder(subject_id="1234")
         resp = await authenticated_client.post("/api/v1/samples/", json=payload)
         assert resp.status_code == 422
 
     @pytest.mark.asyncio
-    async def test_create_sample_collection_date_future(self, authenticated_client, test_data_builder):
+    async def test_create_sample_collection_date_future(
+        self, authenticated_client, test_data_builder
+    ):
         future_date = date.today() + timedelta(days=1)
         payload = test_data_builder(collection_date=str(future_date))
         resp = await authenticated_client.post("/api/v1/samples/", json=payload)
         assert resp.status_code == 422
 
     @pytest.mark.asyncio
-    async def test_create_sample_tissue_storage_rule(self, authenticated_client, test_data_builder):
-        payload = test_data_builder(sample_type="tissue", storage_location="room-1-shelfA")
+    async def test_create_sample_tissue_storage_rule(
+        self, authenticated_client, test_data_builder
+    ):
+        payload = test_data_builder(
+            sample_type="tissue", storage_location="room-1-shelfA"
+        )
         resp = await authenticated_client.post("/api/v1/samples/", json=payload)
         assert resp.status_code == 422
 
@@ -53,7 +61,9 @@ class TestSampleListing:
         assert len(data["samples"]) == len(test_samples_user1)
 
     @pytest.mark.asyncio
-    async def test_list_samples_pagination(self, authenticated_client, test_samples_user1):
+    async def test_list_samples_pagination(
+        self, authenticated_client, test_samples_user1
+    ):
         resp = await authenticated_client.get("/api/v1/samples/?skip=1&limit=1")
         assert resp.status_code == 200
         data = resp.json()
@@ -63,30 +73,43 @@ class TestSampleListing:
         assert data["total"] == len(test_samples_user1)
 
     @pytest.mark.asyncio
-    async def test_list_samples_filter_type(self, authenticated_client, test_samples_user1):
+    async def test_list_samples_filter_type(
+        self, authenticated_client, test_samples_user1
+    ):
         resp = await authenticated_client.get("/api/v1/samples/?sample_type=blood")
         assert resp.status_code == 200
         data = resp.json()
         assert all(s["sample_type"] == "blood" for s in data["samples"])
 
     @pytest.mark.asyncio
-    async def test_list_samples_filter_status(self, authenticated_client, test_samples_user1):
-        resp = await authenticated_client.get("/api/v1/samples/?sample_status=processing")
+    async def test_list_samples_filter_status(
+        self, authenticated_client, test_samples_user1
+    ):
+        resp = await authenticated_client.get(
+            "/api/v1/samples/?sample_status=processing"
+        )
         assert resp.status_code == 200
         data = resp.json()
         assert all(s["status"] == "processing" for s in data["samples"])
 
     @pytest.mark.asyncio
-    async def test_list_samples_date_range(self, authenticated_client, test_samples_user1):
+    async def test_list_samples_date_range(
+        self, authenticated_client, test_samples_user1
+    ):
         resp = await authenticated_client.get(
             "/api/v1/samples/?collection_date_from=2024-01-16&collection_date_to=2024-01-17"
         )
         assert resp.status_code == 200
         data = resp.json()
-        assert all("2024-01-16" <= s["collection_date"] <= "2024-01-17" for s in data["samples"])
+        assert all(
+            "2024-01-16" <= s["collection_date"] <= "2024-01-17"
+            for s in data["samples"]
+        )
 
     @pytest.mark.asyncio
-    async def test_list_samples_empty_results(self, authenticated_client, test_samples_user1):
+    async def test_list_samples_empty_results(
+        self, authenticated_client, test_samples_user1
+    ):
         resp = await authenticated_client.get("/api/v1/samples/?sample_type=saliva")
         assert resp.status_code == 200
         data = resp.json()
@@ -111,7 +134,9 @@ class TestSampleDetail:
         assert data["id"] == str(sample.id)
 
     @pytest.mark.asyncio
-    async def test_get_sample_other_user(self, authenticated_client, test_samples_user2):
+    async def test_get_sample_other_user(
+        self, authenticated_client, test_samples_user2
+    ):
         sample = test_samples_user2[0]
         resp = await authenticated_client.get(f"/api/v1/samples/{sample.id}")
         assert resp.status_code == 403
@@ -136,35 +161,51 @@ class TestSampleUpdate:
     async def test_update_sample(self, authenticated_client, test_samples_user1):
         sample = test_samples_user1[0]
         payload = {"status": "processing"}
-        resp = await authenticated_client.put(f"/api/v1/samples/{sample.id}", json=payload)
+        resp = await authenticated_client.put(
+            f"/api/v1/samples/{sample.id}", json=payload
+        )
         assert resp.status_code == 200
         assert resp.json()["status"] == "processing"
 
     @pytest.mark.asyncio
-    async def test_update_sample_partial(self, authenticated_client, test_samples_user1):
+    async def test_update_sample_partial(
+        self, authenticated_client, test_samples_user1
+    ):
         sample = test_samples_user1[1]
         payload = {"storage_location": "freezer-9-rowZ"}
-        resp = await authenticated_client.put(f"/api/v1/samples/{sample.id}", json=payload)
+        resp = await authenticated_client.put(
+            f"/api/v1/samples/{sample.id}", json=payload
+        )
         assert resp.status_code == 200
         assert resp.json()["storage_location"] == "freezer-9-rowZ"
 
     @pytest.mark.asyncio
-    async def test_update_sample_other_user(self, authenticated_client, test_samples_user2):
+    async def test_update_sample_other_user(
+        self, authenticated_client, test_samples_user2
+    ):
         sample = test_samples_user2[0]
-        resp = await authenticated_client.put(f"/api/v1/samples/{sample.id}", json={"status": "archived"})
+        resp = await authenticated_client.put(
+            f"/api/v1/samples/{sample.id}", json={"status": "archived"}
+        )
         assert resp.status_code == 403
 
     @pytest.mark.asyncio
-    async def test_update_sample_validation_error(self, authenticated_client, test_samples_user1):
+    async def test_update_sample_validation_error(
+        self, authenticated_client, test_samples_user1
+    ):
         sample = test_samples_user1[0]
-        resp = await authenticated_client.put(f"/api/v1/samples/{sample.id}", json={"subject_id": "1234"})
+        resp = await authenticated_client.put(
+            f"/api/v1/samples/{sample.id}", json={"subject_id": "1234"}
+        )
         assert resp.status_code == 422
 
     @pytest.mark.asyncio
     async def test_update_sample_not_found(self, authenticated_client):
         from uuid import uuid4
 
-        resp = await authenticated_client.put(f"/api/v1/samples/{uuid4()}", json={"status": "processing"})
+        resp = await authenticated_client.put(
+            f"/api/v1/samples/{uuid4()}", json={"status": "processing"}
+        )
         assert resp.status_code == 404
 
 
@@ -181,7 +222,9 @@ class TestSampleDeletion:
         assert resp2.status_code == 404
 
     @pytest.mark.asyncio
-    async def test_delete_sample_other_user(self, authenticated_client, test_samples_user2):
+    async def test_delete_sample_other_user(
+        self, authenticated_client, test_samples_user2
+    ):
         sample = test_samples_user2[0]
         resp = await authenticated_client.delete(f"/api/v1/samples/{sample.id}")
         assert resp.status_code == 403
@@ -198,7 +241,9 @@ class TestSampleStatistics:
     """Tests for GET /samples/statistics endpoint."""
 
     @pytest.mark.asyncio
-    async def test_get_statistics(self, authenticated_client, test_samples_user1, test_samples_user2):
+    async def test_get_statistics(
+        self, authenticated_client, test_samples_user1, test_samples_user2
+    ):
         resp = await authenticated_client.get("/api/v1/samples/stats/overview")
         assert resp.status_code == 200
         data = resp.json()
@@ -217,9 +262,13 @@ class TestSamplesBySubject:
     """Tests for GET /samples/subject/{subject_id} endpoint."""
 
     @pytest.mark.asyncio
-    async def test_get_samples_by_subject(self, authenticated_client, test_samples_user1):
+    async def test_get_samples_by_subject(
+        self, authenticated_client, test_samples_user1
+    ):
         sample = test_samples_user1[0]
-        resp = await authenticated_client.get(f"/api/v1/samples/subject/{sample.subject_id}")
+        resp = await authenticated_client.get(
+            f"/api/v1/samples/subject/{sample.subject_id}"
+        )
         assert resp.status_code == 200
         data = resp.json()
         assert all(s["subject_id"] == sample.subject_id for s in data)

--- a/tests/test_api/test_samples.py
+++ b/tests/test_api/test_samples.py
@@ -1,0 +1,236 @@
+import pytest
+from datetime import date, timedelta
+
+
+class TestSampleCreation:
+    """Tests for POST /samples endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_create_sample_success(self, authenticated_client, test_data_builder):
+        payload = test_data_builder()
+        resp = await authenticated_client.post("/api/v1/samples/", json=payload)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["sample_type"] == payload["sample_type"]
+        assert data["subject_id"] == payload["subject_id"]
+        assert "id" in data and "sample_id" in data
+
+    @pytest.mark.asyncio
+    async def test_create_sample_subject_validation(self, authenticated_client, test_data_builder):
+        payload = test_data_builder(subject_id="1234")
+        resp = await authenticated_client.post("/api/v1/samples/", json=payload)
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_create_sample_collection_date_future(self, authenticated_client, test_data_builder):
+        future_date = date.today() + timedelta(days=1)
+        payload = test_data_builder(collection_date=str(future_date))
+        resp = await authenticated_client.post("/api/v1/samples/", json=payload)
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_create_sample_tissue_storage_rule(self, authenticated_client, test_data_builder):
+        payload = test_data_builder(sample_type="tissue", storage_location="room-1-shelfA")
+        resp = await authenticated_client.post("/api/v1/samples/", json=payload)
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_create_sample_unauthenticated(self, client, test_data_builder):
+        payload = test_data_builder()
+        resp = await client.post("/api/v1/samples/", json=payload)
+        assert resp.status_code == 403
+
+
+class TestSampleListing:
+    """Tests for GET /samples endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_list_samples(self, authenticated_client, test_samples_user1):
+        resp = await authenticated_client.get("/api/v1/samples/")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == len(test_samples_user1)
+        assert len(data["samples"]) == len(test_samples_user1)
+
+    @pytest.mark.asyncio
+    async def test_list_samples_pagination(self, authenticated_client, test_samples_user1):
+        resp = await authenticated_client.get("/api/v1/samples/?skip=1&limit=1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["skip"] == 1
+        assert data["limit"] == 1
+        assert len(data["samples"]) == 1
+        assert data["total"] == len(test_samples_user1)
+
+    @pytest.mark.asyncio
+    async def test_list_samples_filter_type(self, authenticated_client, test_samples_user1):
+        resp = await authenticated_client.get("/api/v1/samples/?sample_type=blood")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert all(s["sample_type"] == "blood" for s in data["samples"])
+
+    @pytest.mark.asyncio
+    async def test_list_samples_filter_status(self, authenticated_client, test_samples_user1):
+        resp = await authenticated_client.get("/api/v1/samples/?sample_status=processing")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert all(s["status"] == "processing" for s in data["samples"])
+
+    @pytest.mark.asyncio
+    async def test_list_samples_date_range(self, authenticated_client, test_samples_user1):
+        resp = await authenticated_client.get(
+            "/api/v1/samples/?collection_date_from=2024-01-16&collection_date_to=2024-01-17"
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert all("2024-01-16" <= s["collection_date"] <= "2024-01-17" for s in data["samples"])
+
+    @pytest.mark.asyncio
+    async def test_list_samples_empty_results(self, authenticated_client, test_samples_user1):
+        resp = await authenticated_client.get("/api/v1/samples/?sample_type=saliva")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 0
+        assert data["samples"] == []
+
+    @pytest.mark.asyncio
+    async def test_list_samples_invalid_pagination(self, authenticated_client):
+        resp = await authenticated_client.get("/api/v1/samples/?skip=-1")
+        assert resp.status_code == 422
+
+
+class TestSampleDetail:
+    """Tests for GET /samples/{id} endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_get_sample_own(self, authenticated_client, test_samples_user1):
+        sample = test_samples_user1[0]
+        resp = await authenticated_client.get(f"/api/v1/samples/{sample.id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == str(sample.id)
+
+    @pytest.mark.asyncio
+    async def test_get_sample_other_user(self, authenticated_client, test_samples_user2):
+        sample = test_samples_user2[0]
+        resp = await authenticated_client.get(f"/api/v1/samples/{sample.id}")
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_get_sample_not_found(self, authenticated_client):
+        from uuid import uuid4
+
+        resp = await authenticated_client.get(f"/api/v1/samples/{uuid4()}")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_sample_invalid_uuid(self, authenticated_client):
+        resp = await authenticated_client.get("/api/v1/samples/not-a-uuid")
+        assert resp.status_code == 422
+
+
+class TestSampleUpdate:
+    """Tests for PUT /samples/{id} endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_update_sample(self, authenticated_client, test_samples_user1):
+        sample = test_samples_user1[0]
+        payload = {"status": "processing"}
+        resp = await authenticated_client.put(f"/api/v1/samples/{sample.id}", json=payload)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "processing"
+
+    @pytest.mark.asyncio
+    async def test_update_sample_partial(self, authenticated_client, test_samples_user1):
+        sample = test_samples_user1[1]
+        payload = {"storage_location": "freezer-9-rowZ"}
+        resp = await authenticated_client.put(f"/api/v1/samples/{sample.id}", json=payload)
+        assert resp.status_code == 200
+        assert resp.json()["storage_location"] == "freezer-9-rowZ"
+
+    @pytest.mark.asyncio
+    async def test_update_sample_other_user(self, authenticated_client, test_samples_user2):
+        sample = test_samples_user2[0]
+        resp = await authenticated_client.put(f"/api/v1/samples/{sample.id}", json={"status": "archived"})
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_update_sample_validation_error(self, authenticated_client, test_samples_user1):
+        sample = test_samples_user1[0]
+        resp = await authenticated_client.put(f"/api/v1/samples/{sample.id}", json={"subject_id": "1234"})
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_update_sample_not_found(self, authenticated_client):
+        from uuid import uuid4
+
+        resp = await authenticated_client.put(f"/api/v1/samples/{uuid4()}", json={"status": "processing"})
+        assert resp.status_code == 404
+
+
+class TestSampleDeletion:
+    """Tests for DELETE /samples/{id} endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_delete_sample(self, authenticated_client, test_samples_user1):
+        sample = test_samples_user1[0]
+        resp = await authenticated_client.delete(f"/api/v1/samples/{sample.id}")
+        assert resp.status_code == 200
+        # verify gone
+        resp2 = await authenticated_client.get(f"/api/v1/samples/{sample.id}")
+        assert resp2.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_sample_other_user(self, authenticated_client, test_samples_user2):
+        sample = test_samples_user2[0]
+        resp = await authenticated_client.delete(f"/api/v1/samples/{sample.id}")
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_delete_sample_not_found(self, authenticated_client):
+        from uuid import uuid4
+
+        resp = await authenticated_client.delete(f"/api/v1/samples/{uuid4()}")
+        assert resp.status_code == 404
+
+
+class TestSampleStatistics:
+    """Tests for GET /samples/statistics endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_get_statistics(self, authenticated_client, test_samples_user1, test_samples_user2):
+        resp = await authenticated_client.get("/api/v1/samples/stats/overview")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_samples"] == len(test_samples_user1)
+        assert data["by_type"]["blood"] == 2
+        assert data["by_type"].get("saliva", 0) == 0
+        assert data["by_type"]["tissue"] == 1
+
+    @pytest.mark.asyncio
+    async def test_get_statistics_unauthenticated(self, client):
+        resp = await client.get("/api/v1/samples/stats/overview")
+        assert resp.status_code == 403
+
+
+class TestSamplesBySubject:
+    """Tests for GET /samples/subject/{subject_id} endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_get_samples_by_subject(self, authenticated_client, test_samples_user1):
+        sample = test_samples_user1[0]
+        resp = await authenticated_client.get(f"/api/v1/samples/subject/{sample.subject_id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert all(s["subject_id"] == sample.subject_id for s in data)
+
+    @pytest.mark.asyncio
+    async def test_get_samples_by_subject_no_results(self, authenticated_client):
+        resp = await authenticated_client.get("/api/v1/samples/subject/P999")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    @pytest.mark.asyncio
+    async def test_get_samples_by_subject_invalid(self, authenticated_client):
+        resp = await authenticated_client.get("/api/v1/samples/subject/1234")
+        assert resp.status_code == 422

--- a/tests/test_core/test_exceptions.py
+++ b/tests/test_core/test_exceptions.py
@@ -1,0 +1,42 @@
+import pytest
+
+from app.core.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
+    ConflictError,
+    NotFoundError,
+    ValidationError,
+)
+
+
+def test_validation_error_to_dict():
+    exc = ValidationError(field="email", message="bad")
+    data = exc.to_dict()
+    assert data["error_code"] == "VALIDATION_ERROR"
+    assert data["details"]["field"] == "email"
+    assert data["message"] == "bad"
+
+
+def test_authentication_error_details():
+    exc = AuthenticationError(details={"hint": "login"})
+    data = exc.to_dict()
+    assert exc.status_code == 401
+    assert data["details"]["hint"] == "login"
+
+
+def test_authorization_error_resource():
+    exc = AuthorizationError(resource="sample")
+    assert "sample" in exc.message
+    assert exc.status_code == 403
+
+
+def test_not_found_error_message():
+    exc = NotFoundError(resource="Sample", resource_id="123")
+    assert "Sample" in exc.message and "123" in exc.message
+    assert exc.status_code == 404
+
+
+def test_conflict_error():
+    exc = ConflictError(resource="User")
+    assert "User" in exc.message
+    assert exc.status_code == 409

--- a/tests/test_core/test_logging_module.py
+++ b/tests/test_core/test_logging_module.py
@@ -1,0 +1,89 @@
+import asyncio
+import logging
+import uuid
+
+import pytest
+
+from app.core import logging as log_mod
+
+
+@pytest.fixture(autouse=True)
+def clean_root_logger():
+    root = logging.getLogger()
+    old_handlers = root.handlers[:]
+    yield
+    for h in root.handlers[:]:
+        root.removeHandler(h)
+    for h in old_handlers:
+        root.addHandler(h)
+
+
+def _basic_env(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://u:p@localhost/db")
+    monkeypatch.setenv("SECRET_KEY", "secret")
+
+
+def test_setup_logging_structured(tmp_path, monkeypatch):
+    _basic_env(monkeypatch)
+    log_file = tmp_path / "service.log"
+    log_mod.setup_logging(
+        log_level="DEBUG",
+        log_file=str(log_file),
+        enable_rotation=False,
+        structured_logging=True,
+    )
+    root = logging.getLogger()
+    assert root.level == logging.DEBUG
+    assert any(isinstance(h, logging.StreamHandler) for h in root.handlers)
+    assert any(isinstance(h, logging.FileHandler) for h in root.handlers)
+    assert any(isinstance(h.formatter, log_mod.StructuredFormatter) for h in root.handlers)
+    root.info("hello")
+    assert log_file.exists()
+
+
+def test_correlation_id_utilities():
+    log_mod.set_correlation_id("abc")
+    assert log_mod.get_correlation_id() == "abc"
+    new_id = log_mod.generate_correlation_id()
+    uuid.UUID(new_id)
+    # existing correlation id should remain unchanged
+    assert log_mod.get_correlation_id() == "abc"
+    log_mod.set_correlation_id("")
+    assert log_mod.get_correlation_id() == ""
+
+
+@pytest.mark.asyncio
+async def test_correlation_id_async_propagation():
+    log_mod.set_correlation_id("cid")
+
+    async def nested():
+        await asyncio.sleep(0)
+        return log_mod.get_correlation_id()
+
+    assert await nested() == "cid"
+
+
+def test_log_error(caplog):
+    with caplog.at_level(logging.ERROR):
+        try:
+            raise ValueError("boom")
+        except ValueError as exc:
+            log_mod.log_error(exc, {"foo": "bar"})
+    record = caplog.records[0]
+    assert record.error_type == "ValueError"
+    assert record.context == {"foo": "bar"}
+    assert record.exc_info
+
+
+def test_log_request_and_response(caplog):
+    headers = {"Authorization": "secret", "User-Agent": "tester", "x-forwarded-for": "1.1.1.1"}
+    with caplog.at_level(logging.INFO):
+        log_mod.log_request("POST", "/unit", headers, body={"password": "x", "a": 1})
+        log_mod.log_response(200, 0.123, 10)
+    req = caplog.records[0]
+    resp = caplog.records[1]
+    assert req.event == "request_received"
+    assert req.method == "POST"
+    assert "password" not in req.body
+    assert resp.status_code == 200
+    assert resp.response_size_bytes == 10

--- a/tests/test_core/test_logging_module.py
+++ b/tests/test_core/test_logging_module.py
@@ -36,7 +36,9 @@ def test_setup_logging_structured(tmp_path, monkeypatch):
     assert root.level == logging.DEBUG
     assert any(isinstance(h, logging.StreamHandler) for h in root.handlers)
     assert any(isinstance(h, logging.FileHandler) for h in root.handlers)
-    assert any(isinstance(h.formatter, log_mod.StructuredFormatter) for h in root.handlers)
+    assert any(
+        isinstance(h.formatter, log_mod.StructuredFormatter) for h in root.handlers
+    )
     root.info("hello")
     assert log_file.exists()
 
@@ -76,7 +78,11 @@ def test_log_error(caplog):
 
 
 def test_log_request_and_response(caplog):
-    headers = {"Authorization": "secret", "User-Agent": "tester", "x-forwarded-for": "1.1.1.1"}
+    headers = {
+        "Authorization": "secret",
+        "User-Agent": "tester",
+        "x-forwarded-for": "1.1.1.1",
+    }
     with caplog.at_level(logging.INFO):
         log_mod.log_request("POST", "/unit", headers, body={"password": "x", "a": 1})
         log_mod.log_response(200, 0.123, 10)

--- a/tests/test_integration/test_user_journey.py
+++ b/tests/test_integration/test_user_journey.py
@@ -1,4 +1,5 @@
 import pytest
+
 from tests.helpers import build_sample_data, token_headers_for_user
 
 

--- a/tests/test_integration/test_user_journey.py
+++ b/tests/test_integration/test_user_journey.py
@@ -1,0 +1,45 @@
+import pytest
+from tests.helpers import build_sample_data, token_headers_for_user
+
+
+@pytest.mark.asyncio
+async def test_end_to_end_flow(client, test_user2):
+    # register new user and login
+    reg_data = {
+        "username": "journey",
+        "email": "journey@test.com",
+        "password": "StrongPass1$",
+    }
+    resp = await client.post("/api/v1/auth/register", json=reg_data)
+    assert resp.status_code == 200
+    login_resp = await client.post("/api/v1/auth/login", json={"email": reg_data["email"], "password": reg_data["password"]})
+    assert login_resp.status_code == 200
+    token = login_resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # create sample
+    payload = build_sample_data()
+    resp = await client.post("/api/v1/samples/", json=payload, headers=headers)
+    assert resp.status_code == 200
+    sample_id = resp.json()["id"]
+
+    # query with filters
+    list_resp = await client.get("/api/v1/samples/", headers=headers, params={"sample_type": "blood"})
+    assert list_resp.status_code == 200
+    assert list_resp.json()["total"] >= 1
+
+    # update
+    upd_resp = await client.put(f"/api/v1/samples/{sample_id}", json={"status": "processing"}, headers=headers)
+    assert upd_resp.status_code == 200
+
+    # other user cannot delete
+    resp = await client.delete(f"/api/v1/samples/{sample_id}", headers=token_headers_for_user(test_user2))
+    assert resp.status_code == 403
+
+    # delete sample
+    del_resp = await client.delete(f"/api/v1/samples/{sample_id}", headers=headers)
+    assert del_resp.status_code == 200
+
+    # logout (simulate token expiry)
+    logout_resp = await client.post("/api/v1/auth/refresh", headers=headers)
+    assert logout_resp.status_code == 200

--- a/tests/test_integration/test_user_journey.py
+++ b/tests/test_integration/test_user_journey.py
@@ -12,7 +12,10 @@ async def test_end_to_end_flow(client, test_user2):
     }
     resp = await client.post("/api/v1/auth/register", json=reg_data)
     assert resp.status_code == 200
-    login_resp = await client.post("/api/v1/auth/login", json={"email": reg_data["email"], "password": reg_data["password"]})
+    login_resp = await client.post(
+        "/api/v1/auth/login",
+        json={"email": reg_data["email"], "password": reg_data["password"]},
+    )
     assert login_resp.status_code == 200
     token = login_resp.json()["access_token"]
     headers = {"Authorization": f"Bearer {token}"}
@@ -24,16 +27,22 @@ async def test_end_to_end_flow(client, test_user2):
     sample_id = resp.json()["id"]
 
     # query with filters
-    list_resp = await client.get("/api/v1/samples/", headers=headers, params={"sample_type": "blood"})
+    list_resp = await client.get(
+        "/api/v1/samples/", headers=headers, params={"sample_type": "blood"}
+    )
     assert list_resp.status_code == 200
     assert list_resp.json()["total"] >= 1
 
     # update
-    upd_resp = await client.put(f"/api/v1/samples/{sample_id}", json={"status": "processing"}, headers=headers)
+    upd_resp = await client.put(
+        f"/api/v1/samples/{sample_id}", json={"status": "processing"}, headers=headers
+    )
     assert upd_resp.status_code == 200
 
     # other user cannot delete
-    resp = await client.delete(f"/api/v1/samples/{sample_id}", headers=token_headers_for_user(test_user2))
+    resp = await client.delete(
+        f"/api/v1/samples/{sample_id}", headers=token_headers_for_user(test_user2)
+    )
     assert resp.status_code == 403
 
     # delete sample

--- a/tests/test_middleware/test_logging.py
+++ b/tests/test_middleware/test_logging.py
@@ -1,6 +1,7 @@
 import json
+
 import pytest
-from fastapi import Body, Response, Request
+from fastapi import Body, Request, Response
 from fastapi.responses import StreamingResponse
 
 
@@ -80,7 +81,7 @@ class TestLoggingMiddleware:
             "app.middleware.logging_middleware.log_error", fake_log_error
         )
 
-        from httpx import AsyncClient, ASGITransport
+        from httpx import ASGITransport, AsyncClient
 
         transport = ASGITransport(app_with_overrides, raise_app_exceptions=False)
         async with AsyncClient(transport=transport, base_url="http://testserver") as ac:
@@ -120,7 +121,7 @@ class TestLoggingMiddleware:
             "app.middleware.logging_middleware.log_response", fake_log_response
         )
 
-        from httpx import AsyncClient, ASGITransport
+        from httpx import ASGITransport, AsyncClient
 
         transport = ASGITransport(app_with_overrides, raise_app_exceptions=False)
         async with AsyncClient(transport=transport, base_url="http://testserver") as ac:

--- a/tests/test_middleware/test_logging.py
+++ b/tests/test_middleware/test_logging.py
@@ -1,0 +1,137 @@
+import json
+import pytest
+from fastapi import Body, Response, Request
+from fastapi.responses import StreamingResponse
+
+
+class TestLoggingMiddleware:
+    """Tests for LoggingMiddleware behavior."""
+
+    @pytest.mark.asyncio
+    async def test_correlation_id_generation(self, client, monkeypatch):
+        monkeypatch.setattr(
+            "app.middleware.logging_middleware.generate_correlation_id",
+            lambda: "test-corr-id",
+        )
+        resp = await client.get("/health")
+        assert resp.status_code == 200
+        assert resp.headers["X-Correlation-ID"] == "test-corr-id"
+
+    @pytest.mark.asyncio
+    async def test_request_and_response_logging(self, client, test_user1, monkeypatch):
+        captured = {}
+
+        from app.middleware import logging_middleware as lm
+        orig_log_request = lm.log_request
+        orig_log_response = lm.log_response
+
+        def fake_log_request(method, url, headers, body=None):
+            captured["request"] = {
+                "method": method,
+                "url": url,
+                "headers": headers,
+                "body": body,
+            }
+            orig_log_request(method, url, headers, body)
+
+        def fake_log_response(status_code, response_time, response_size=0):
+            captured["response"] = {
+                "status_code": status_code,
+                "response_time": response_time,
+                "response_size": response_size,
+            }
+            orig_log_response(status_code, response_time, response_size)
+
+        monkeypatch.setattr(
+            "app.middleware.logging_middleware.log_request", fake_log_request
+        )
+        monkeypatch.setattr(
+            "app.middleware.logging_middleware.log_response", fake_log_response
+        )
+
+        login_data = {"email": test_user1.email, "password": "testpass123"}
+        resp = await client.post("/api/v1/auth/login?foo=bar", json=login_data)
+        assert resp.status_code in {200, 401}
+        assert captured["request"]["method"] == "POST"
+        assert "/api/v1/auth/login" in captured["request"]["url"]
+        assert "host" in {k.lower() for k in captured["request"]["headers"].keys()}
+        assert captured["request"]["body"].get("email") == test_user1.email
+        assert captured["response"]["status_code"] == resp.status_code
+        assert captured["response"]["response_size"] >= 0
+        assert captured["response"]["response_time"] >= 0
+
+    @pytest.mark.asyncio
+    async def test_error_logging(self, app_with_overrides, monkeypatch):
+        async def err_route():
+            raise RuntimeError("boom")
+
+        app_with_overrides.add_api_route("/err", err_route, methods=["GET"])
+
+        captured = {}
+
+        def fake_log_error(error, context):
+            captured["error"] = {
+                "type": type(error).__name__,
+                "context": context,
+            }
+
+        monkeypatch.setattr(
+            "app.middleware.logging_middleware.log_error", fake_log_error
+        )
+
+        from httpx import AsyncClient, ASGITransport
+
+        transport = ASGITransport(app_with_overrides, raise_app_exceptions=False)
+        async with AsyncClient(transport=transport, base_url="http://testserver") as ac:
+            resp = await ac.get("/err")
+        assert resp.status_code == 500
+        assert captured["error"]["type"] == "RuntimeError"
+        assert captured["error"]["context"]["request_method"] == "GET"
+
+    @pytest.mark.asyncio
+    async def test_edge_cases(self, app_with_overrides, monkeypatch):
+        async def echo_bytes(request: Request):
+            data = await request.body()
+            return Response(content=data, media_type="application/octet-stream")
+
+        async def stream():
+            async def generator():
+                for i in range(3):
+                    yield f"{i}\n"
+            return StreamingResponse(generator(), media_type="text/plain")
+
+        app_with_overrides.add_api_route("/binary", echo_bytes, methods=["POST"])
+        app_with_overrides.add_api_route("/stream", stream, methods=["GET"])
+
+        records = []
+
+        def fake_log_request(method, url, headers, body=None):
+            records.append(body)
+
+        def fake_log_response(status_code, response_time, response_size=0):
+            records.append(response_size)
+
+        monkeypatch.setattr(
+            "app.middleware.logging_middleware.log_request", fake_log_request
+        )
+        monkeypatch.setattr(
+            "app.middleware.logging_middleware.log_response", fake_log_response
+        )
+
+        from httpx import AsyncClient, ASGITransport
+
+        transport = ASGITransport(app_with_overrides, raise_app_exceptions=False)
+        async with AsyncClient(transport=transport, base_url="http://testserver") as ac:
+            big_data = "x" * 5000
+            resp1 = await ac.post(
+                "/binary",
+                content=big_data.encode(),
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp1.status_code == 200
+            resp2 = await ac.get("/stream")
+            assert resp2.status_code == 200
+
+        assert records[0] == {"raw_body_size": len(big_data.encode())}
+        # response size for streaming should be 0
+        assert records[-1] == 0

--- a/tests/test_middleware/test_logging.py
+++ b/tests/test_middleware/test_logging.py
@@ -22,6 +22,7 @@ class TestLoggingMiddleware:
         captured = {}
 
         from app.middleware import logging_middleware as lm
+
         orig_log_request = lm.log_request
         orig_log_response = lm.log_response
 
@@ -98,6 +99,7 @@ class TestLoggingMiddleware:
             async def generator():
                 for i in range(3):
                     yield f"{i}\n"
+
             return StreamingResponse(generator(), media_type="text/plain")
 
         app_with_overrides.add_api_route("/binary", echo_bytes, methods=["POST"])

--- a/tests/test_middleware/test_security.py
+++ b/tests/test_middleware/test_security.py
@@ -1,17 +1,18 @@
 import asyncio
+
 import pytest
 import pytest_asyncio
 from starlette.requests import Request
 from starlette.responses import Response
 
+from app.core.exceptions import RateLimitError, ValidationError
+from app.middleware.logging_middleware import SecurityLoggingMiddleware
 from app.middleware.security_middleware import (
+    ContentTypeValidationMiddleware,
+    PayloadSizeValidationMiddleware,
     RateLimitMiddleware,
     SecurityHeadersMiddleware,
-    PayloadSizeValidationMiddleware,
-    ContentTypeValidationMiddleware,
 )
-from app.middleware.logging_middleware import SecurityLoggingMiddleware
-from app.core.exceptions import RateLimitError, ValidationError
 
 
 def make_request(method: str = "GET", path: str = "/", headers=None, body: bytes = b""):

--- a/tests/test_middleware/test_security.py
+++ b/tests/test_middleware/test_security.py
@@ -1,0 +1,169 @@
+import asyncio
+import pytest
+import pytest_asyncio
+from starlette.requests import Request
+from starlette.responses import Response
+
+from app.middleware.security_middleware import (
+    RateLimitMiddleware,
+    SecurityHeadersMiddleware,
+    PayloadSizeValidationMiddleware,
+    ContentTypeValidationMiddleware,
+)
+from app.middleware.logging_middleware import SecurityLoggingMiddleware
+from app.core.exceptions import RateLimitError, ValidationError
+
+
+def make_request(method: str = "GET", path: str = "/", headers=None, body: bytes = b""):
+    if headers is None:
+        headers = {}
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "headers": [(k.encode(), v.encode()) for k, v in headers.items()],
+        "query_string": b"",
+        "client": ("test", 0),
+    }
+    return Request(scope, receive)
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_counting():
+    async def endpoint(request):
+        return Response("ok")
+
+    middleware = RateLimitMiddleware(
+        endpoint, requests_per_minute=2, burst_limit=2, window_size=1
+    )
+    middleware._get_client_ip = lambda req: "1.1.1.1"
+
+    await middleware.dispatch(make_request(), endpoint)
+    await middleware.dispatch(make_request(), endpoint)
+
+    assert len(middleware.requests["1.1.1.1"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_exceeded():
+    async def endpoint(request):
+        return Response("ok")
+
+    middleware = RateLimitMiddleware(
+        endpoint, requests_per_minute=2, burst_limit=2, window_size=1
+    )
+    middleware._get_client_ip = lambda req: "2.2.2.2"
+
+    await middleware.dispatch(make_request(), endpoint)
+    await middleware.dispatch(make_request(), endpoint)
+    with pytest.raises(RateLimitError):
+        await middleware.dispatch(make_request(), endpoint)
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_whitelist():
+    async def endpoint(request):
+        return Response("ok")
+
+    middleware = RateLimitMiddleware(
+        endpoint,
+        requests_per_minute=1,
+        burst_limit=1,
+        window_size=1,
+        whitelist={"3.3.3.3"},
+    )
+    middleware._get_client_ip = lambda req: "3.3.3.3"
+
+    await middleware.dispatch(make_request(), endpoint)
+    await middleware.dispatch(make_request(), endpoint)
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_resets_after_window():
+    async def endpoint(request):
+        return Response("ok")
+
+    middleware = RateLimitMiddleware(
+        endpoint, requests_per_minute=1, burst_limit=1, window_size=1
+    )
+    middleware._get_client_ip = lambda req: "4.4.4.4"
+
+    await middleware.dispatch(make_request(), endpoint)
+    await asyncio.sleep(1.1)
+    await middleware.dispatch(make_request(), endpoint)
+
+
+@pytest.mark.asyncio
+async def test_security_headers_added():
+    called = False
+
+    async def endpoint(request):
+        nonlocal called
+        called = True
+        return Response("ok")
+
+    middleware = SecurityHeadersMiddleware(endpoint)
+    response = await middleware.dispatch(make_request(), endpoint)
+
+    assert called
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+    assert response.headers["X-Frame-Options"] == "DENY"
+    assert response.headers["X-XSS-Protection"] == "1; mode=block"
+    assert "default-src" in response.headers["Content-Security-Policy"]
+
+
+@pytest.mark.asyncio
+async def test_attack_detection(monkeypatch):
+    events = []
+
+    def recorder(event_type, details):
+        events.append(event_type)
+
+    monkeypatch.setattr(
+        "app.middleware.logging_middleware.log_security_event",
+        recorder,
+    )
+    middleware = SecurityLoggingMiddleware(lambda r: Response("ok"))
+
+    async def endpoint(request):
+        return Response("ok")
+
+    req = make_request(path="/health?q=select")
+    await middleware.dispatch(req, endpoint)
+    assert "suspicious_request" in events
+
+
+@pytest.mark.asyncio
+async def test_payload_size_validation():
+    async def endpoint(request):
+        return Response("ok")
+
+    middleware = PayloadSizeValidationMiddleware(endpoint, max_size_mb=0)
+    req = make_request(
+        method="POST",
+        path="/",
+        headers={"content-type": "application/json"},
+        body=b"x" * 1024,
+    )
+    with pytest.raises(ValidationError):
+        await middleware.dispatch(req, endpoint)
+
+
+@pytest.mark.asyncio
+async def test_content_type_validation():
+    async def endpoint2(request):
+        return Response("ok")
+
+    middleware = ContentTypeValidationMiddleware(endpoint2)
+    req = make_request(
+        method="POST",
+        path="/submit",
+        headers={"content-type": "text/plain"},
+        body=b"hello",
+    )
+    with pytest.raises(ValidationError):
+        await middleware.dispatch(req, endpoint2)

--- a/tests/test_repositories/test_sample_repository.py
+++ b/tests/test_repositories/test_sample_repository.py
@@ -1,7 +1,8 @@
-import pytest
-from sqlalchemy.exc import SQLAlchemyError
 from datetime import date, timedelta
 from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
 
 from app.models.sample import SampleStatus, SampleType
 from app.repositories.sample_repository import SampleRepository

--- a/tests/test_repositories/test_sample_repository.py
+++ b/tests/test_repositories/test_sample_repository.py
@@ -1,0 +1,41 @@
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+from datetime import date, timedelta
+from uuid import uuid4
+
+from app.models.sample import SampleStatus, SampleType
+from app.repositories.sample_repository import SampleRepository
+from app.schemas.sample import SampleFilter
+
+
+class TestSampleRepository:
+    @pytest.mark.asyncio
+    async def test_filter_combination(self, sample_repository: SampleRepository, test_samples_user1):
+        filt = SampleFilter(
+            sample_type=SampleType.BLOOD,
+            status=SampleStatus.COLLECTED,
+            collection_date_from=date(2024, 1, 1),
+            collection_date_to=date(2024, 12, 31),
+        )
+        results = await sample_repository.get_samples_with_filters(filt, user_id=test_samples_user1[0].user_id)
+        assert len(results) == 1
+        assert results[0].subject_id == "P001"
+
+    @pytest.mark.asyncio
+    async def test_count_no_results(self, sample_repository: SampleRepository, test_samples_user1):
+        filt = SampleFilter(subject_id="Z999")
+        count = await sample_repository.count_samples_with_filters(filt, user_id=test_samples_user1[0].user_id)
+        assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_get_samples_by_subject_no_user(self, sample_repository: SampleRepository, test_samples_user1):
+        results = await sample_repository.get_samples_by_subject_id("P001")
+        assert len(results) >= 1
+
+    @pytest.mark.asyncio
+    async def test_db_error_handled(self, sample_repository: SampleRepository, monkeypatch):
+        async def boom(*args, **kwargs):
+            raise SQLAlchemyError("db fail")
+        monkeypatch.setattr(sample_repository.db, "execute", boom)
+        with pytest.raises(SQLAlchemyError):
+            await sample_repository.get_sample_by_id(uuid4())

--- a/tests/test_repositories/test_sample_repository.py
+++ b/tests/test_repositories/test_sample_repository.py
@@ -1,8 +1,10 @@
+import asyncio
 from datetime import date, timedelta
 from uuid import uuid4
 
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.models.sample import SampleStatus, SampleType
 from app.repositories.sample_repository import SampleRepository
@@ -53,3 +55,42 @@ class TestSampleRepository:
         monkeypatch.setattr(sample_repository.db, "execute", boom)
         with pytest.raises(SQLAlchemyError):
             await sample_repository.get_sample_by_id(uuid4())
+
+    @pytest.mark.asyncio
+    async def test_concurrent_creations(self, async_engine, test_user1):
+        """Repository handles concurrent inserts using separate sessions."""
+        session_maker = async_sessionmaker(
+            bind=async_engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+        async with session_maker() as s1, session_maker() as s2:
+            repo1 = SampleRepository(s1)
+            repo2 = SampleRepository(s2)
+            data1 = {
+                "sample_type": SampleType.BLOOD,
+                "subject_id": "PX1",
+                "collection_date": date.today(),
+                "status": SampleStatus.COLLECTED,
+                "storage_location": "freezer-1-rowA",
+                "user_id": test_user1.id,
+            }
+            data2 = {
+                "sample_type": SampleType.BLOOD,
+                "subject_id": "PX2",
+                "collection_date": date.today(),
+                "status": SampleStatus.COLLECTED,
+                "storage_location": "freezer-1-rowB",
+                "user_id": test_user1.id,
+            }
+
+            await asyncio.gather(
+                repo1.create_sample(data1),
+                repo2.create_sample(data2),
+            )
+
+        async with session_maker() as check:
+            repo = SampleRepository(check)
+            count = await repo.count_samples_with_filters(
+                SampleFilter(), user_id=test_user1.id
+            )
+            assert count >= 2

--- a/tests/test_repositories/test_sample_repository.py
+++ b/tests/test_repositories/test_sample_repository.py
@@ -10,32 +10,45 @@ from app.schemas.sample import SampleFilter
 
 class TestSampleRepository:
     @pytest.mark.asyncio
-    async def test_filter_combination(self, sample_repository: SampleRepository, test_samples_user1):
+    async def test_filter_combination(
+        self, sample_repository: SampleRepository, test_samples_user1
+    ):
         filt = SampleFilter(
             sample_type=SampleType.BLOOD,
             status=SampleStatus.COLLECTED,
             collection_date_from=date(2024, 1, 1),
             collection_date_to=date(2024, 12, 31),
         )
-        results = await sample_repository.get_samples_with_filters(filt, user_id=test_samples_user1[0].user_id)
+        results = await sample_repository.get_samples_with_filters(
+            filt, user_id=test_samples_user1[0].user_id
+        )
         assert len(results) == 1
         assert results[0].subject_id == "P001"
 
     @pytest.mark.asyncio
-    async def test_count_no_results(self, sample_repository: SampleRepository, test_samples_user1):
+    async def test_count_no_results(
+        self, sample_repository: SampleRepository, test_samples_user1
+    ):
         filt = SampleFilter(subject_id="Z999")
-        count = await sample_repository.count_samples_with_filters(filt, user_id=test_samples_user1[0].user_id)
+        count = await sample_repository.count_samples_with_filters(
+            filt, user_id=test_samples_user1[0].user_id
+        )
         assert count == 0
 
     @pytest.mark.asyncio
-    async def test_get_samples_by_subject_no_user(self, sample_repository: SampleRepository, test_samples_user1):
+    async def test_get_samples_by_subject_no_user(
+        self, sample_repository: SampleRepository, test_samples_user1
+    ):
         results = await sample_repository.get_samples_by_subject_id("P001")
         assert len(results) >= 1
 
     @pytest.mark.asyncio
-    async def test_db_error_handled(self, sample_repository: SampleRepository, monkeypatch):
+    async def test_db_error_handled(
+        self, sample_repository: SampleRepository, monkeypatch
+    ):
         async def boom(*args, **kwargs):
             raise SQLAlchemyError("db fail")
+
         monkeypatch.setattr(sample_repository.db, "execute", boom)
         with pytest.raises(SQLAlchemyError):
             await sample_repository.get_sample_by_id(uuid4())

--- a/tests/test_repositories/test_user_repository.py
+++ b/tests/test_repositories/test_user_repository.py
@@ -1,0 +1,41 @@
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.models.user import User
+from app.repositories.user_repository import UserRepository
+from tests.helpers import build_user_data
+
+
+class TestUserRepository:
+    @pytest.mark.asyncio
+    async def test_get_user_by_email_not_found(self, user_repository: UserRepository):
+        user = await user_repository.get_user_by_email("missing@test.com")
+        assert user is None
+
+    @pytest.mark.asyncio
+    async def test_get_user_by_username_not_found(self, user_repository: UserRepository):
+        user = await user_repository.get_user_by_username("missing")
+        assert user is None
+
+    @pytest.mark.asyncio
+    async def test_create_user_duplicate_email(self, user_repository: UserRepository):
+        data = build_user_data()
+        await user_repository.create_user({
+            "username": data["username"],
+            "email": data["email"],
+            "hashed_password": "x",
+            "is_active": True,
+        })
+        with pytest.raises(IntegrityError):
+            await user_repository.create_user({
+                "username": data["username"] + "a",
+                "email": data["email"],
+                "hashed_password": "y",
+                "is_active": True,
+            })
+
+    @pytest.mark.asyncio
+    async def test_update_user_not_found(self, user_repository: UserRepository):
+        import uuid
+        user = await user_repository.update_user(uuid.UUID("00000000-0000-0000-0000-000000000000"), {"username": "none"})
+        assert user is None

--- a/tests/test_repositories/test_user_repository.py
+++ b/tests/test_repositories/test_user_repository.py
@@ -13,29 +13,38 @@ class TestUserRepository:
         assert user is None
 
     @pytest.mark.asyncio
-    async def test_get_user_by_username_not_found(self, user_repository: UserRepository):
+    async def test_get_user_by_username_not_found(
+        self, user_repository: UserRepository
+    ):
         user = await user_repository.get_user_by_username("missing")
         assert user is None
 
     @pytest.mark.asyncio
     async def test_create_user_duplicate_email(self, user_repository: UserRepository):
         data = build_user_data()
-        await user_repository.create_user({
-            "username": data["username"],
-            "email": data["email"],
-            "hashed_password": "x",
-            "is_active": True,
-        })
-        with pytest.raises(IntegrityError):
-            await user_repository.create_user({
-                "username": data["username"] + "a",
+        await user_repository.create_user(
+            {
+                "username": data["username"],
                 "email": data["email"],
-                "hashed_password": "y",
+                "hashed_password": "x",
                 "is_active": True,
-            })
+            }
+        )
+        with pytest.raises(IntegrityError):
+            await user_repository.create_user(
+                {
+                    "username": data["username"] + "a",
+                    "email": data["email"],
+                    "hashed_password": "y",
+                    "is_active": True,
+                }
+            )
 
     @pytest.mark.asyncio
     async def test_update_user_not_found(self, user_repository: UserRepository):
         import uuid
-        user = await user_repository.update_user(uuid.UUID("00000000-0000-0000-0000-000000000000"), {"username": "none"})
+
+        user = await user_repository.update_user(
+            uuid.UUID("00000000-0000-0000-0000-000000000000"), {"username": "none"}
+        )
         assert user is None

--- a/tests/test_schemas/test_auth_schemas.py
+++ b/tests/test_schemas/test_auth_schemas.py
@@ -9,7 +9,9 @@ class TestAuthSchemas:
         with pytest.raises(ValidationError):
             UserCreate(username="user1", email="user1@test.com", password="weak")
         with pytest.raises(ValidationError):
-            UserCreate(username="user1", email="user1@test.com", password="alllowercase1!")
+            UserCreate(
+                username="user1", email="user1@test.com", password="alllowercase1!"
+            )
         with pytest.raises(ValidationError):
             UserCreate(username="user1", email="user1@test.com", password="PASSWORD1!")
         with pytest.raises(ValidationError):
@@ -23,6 +25,8 @@ class TestAuthSchemas:
 
     def test_username_edge_cases(self):
         with pytest.raises(ValidationError):
-            UserCreate(username="1invalid", email="user1@test.com", password="Password1!")
+            UserCreate(
+                username="1invalid", email="user1@test.com", password="Password1!"
+            )
         with pytest.raises(ValidationError):
             UserCreate(username="admin", email="user1@test.com", password="Password1!")

--- a/tests/test_schemas/test_auth_schemas.py
+++ b/tests/test_schemas/test_auth_schemas.py
@@ -1,0 +1,28 @@
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.auth import UserCreate
+
+
+class TestAuthSchemas:
+    def test_password_complexity(self):
+        with pytest.raises(ValidationError):
+            UserCreate(username="user1", email="user1@test.com", password="weak")
+        with pytest.raises(ValidationError):
+            UserCreate(username="user1", email="user1@test.com", password="alllowercase1!")
+        with pytest.raises(ValidationError):
+            UserCreate(username="user1", email="user1@test.com", password="PASSWORD1!")
+        with pytest.raises(ValidationError):
+            UserCreate(username="user1", email="user1@test.com", password="Password1")
+
+    def test_email_edge_cases(self):
+        with pytest.raises(ValidationError):
+            UserCreate(username="user1", email="bademail", password="Password1!")
+        with pytest.raises(ValidationError):
+            UserCreate(username="user1", email="user1@bad.com", password="Password1!")
+
+    def test_username_edge_cases(self):
+        with pytest.raises(ValidationError):
+            UserCreate(username="1invalid", email="user1@test.com", password="Password1!")
+        with pytest.raises(ValidationError):
+            UserCreate(username="admin", email="user1@test.com", password="Password1!")

--- a/tests/test_schemas/test_sample_schemas.py
+++ b/tests/test_schemas/test_sample_schemas.py
@@ -1,9 +1,10 @@
-import pytest
 from datetime import date, timedelta
+
+import pytest
 from pydantic import ValidationError
 
+from app.models.sample import SampleStatus, SampleType
 from app.schemas.sample import SampleCreate, SampleUpdate
-from app.models.sample import SampleType, SampleStatus
 
 
 class TestSampleSchemas:

--- a/tests/test_schemas/test_sample_schemas.py
+++ b/tests/test_schemas/test_sample_schemas.py
@@ -9,20 +9,40 @@ from app.models.sample import SampleType, SampleStatus
 class TestSampleSchemas:
     def test_subject_id_variations(self):
         with pytest.raises(ValidationError):
-            SampleCreate(sample_type=SampleType.BLOOD, subject_id="123", collection_date=date.today(), storage_location="freezer-1-rowA")
+            SampleCreate(
+                sample_type=SampleType.BLOOD,
+                subject_id="123",
+                collection_date=date.today(),
+                storage_location="freezer-1-rowA",
+            )
 
     def test_date_boundaries(self):
         future = date.today() + timedelta(days=1)
         with pytest.raises(ValidationError):
-            SampleCreate(sample_type=SampleType.BLOOD, subject_id="P123", collection_date=future, storage_location="freezer-1-rowA")
+            SampleCreate(
+                sample_type=SampleType.BLOOD,
+                subject_id="P123",
+                collection_date=future,
+                storage_location="freezer-1-rowA",
+            )
 
     def test_storage_location_validation(self):
         with pytest.raises(ValidationError):
-            SampleCreate(sample_type=SampleType.BLOOD, subject_id="P123", collection_date=date.today(), storage_location="bad-location")
+            SampleCreate(
+                sample_type=SampleType.BLOOD,
+                subject_id="P123",
+                collection_date=date.today(),
+                storage_location="bad-location",
+            )
 
     def test_cross_field_validation(self):
         with pytest.raises(ValidationError):
-            SampleCreate(sample_type=SampleType.TISSUE, subject_id="P123", collection_date=date.today(), storage_location="room-1-shelfA")
+            SampleCreate(
+                sample_type=SampleType.TISSUE,
+                subject_id="P123",
+                collection_date=date.today(),
+                storage_location="room-1-shelfA",
+            )
 
     def test_update_optional_validations(self):
         update = SampleUpdate(subject_id="S001", collection_date=date.today())

--- a/tests/test_schemas/test_sample_schemas.py
+++ b/tests/test_schemas/test_sample_schemas.py
@@ -1,0 +1,29 @@
+import pytest
+from datetime import date, timedelta
+from pydantic import ValidationError
+
+from app.schemas.sample import SampleCreate, SampleUpdate
+from app.models.sample import SampleType, SampleStatus
+
+
+class TestSampleSchemas:
+    def test_subject_id_variations(self):
+        with pytest.raises(ValidationError):
+            SampleCreate(sample_type=SampleType.BLOOD, subject_id="123", collection_date=date.today(), storage_location="freezer-1-rowA")
+
+    def test_date_boundaries(self):
+        future = date.today() + timedelta(days=1)
+        with pytest.raises(ValidationError):
+            SampleCreate(sample_type=SampleType.BLOOD, subject_id="P123", collection_date=future, storage_location="freezer-1-rowA")
+
+    def test_storage_location_validation(self):
+        with pytest.raises(ValidationError):
+            SampleCreate(sample_type=SampleType.BLOOD, subject_id="P123", collection_date=date.today(), storage_location="bad-location")
+
+    def test_cross_field_validation(self):
+        with pytest.raises(ValidationError):
+            SampleCreate(sample_type=SampleType.TISSUE, subject_id="P123", collection_date=date.today(), storage_location="room-1-shelfA")
+
+    def test_update_optional_validations(self):
+        update = SampleUpdate(subject_id="S001", collection_date=date.today())
+        assert update.subject_id == "S001"

--- a/tests/test_services/test_auth_service_business_logic.py
+++ b/tests/test_services/test_auth_service_business_logic.py
@@ -4,6 +4,7 @@ Authentication Business Logic Tests
 These tests verify core authentication business logic for the clinical samples system.
 They ensure proper validation of user registration, duplicate prevention, and login security.
 """
+
 import pytest
 
 from app.core.exceptions import AuthenticationError, ConflictError

--- a/tests/test_services/test_auth_service_security.py
+++ b/tests/test_services/test_auth_service_security.py
@@ -5,6 +5,7 @@ These tests verify critical security components for authentication in the clinic
 All tests are designed to prevent security vulnerabilities that could lead to unauthorized
 access to sensitive medical data.
 """
+
 import uuid
 from datetime import datetime, timedelta, timezone
 

--- a/tests/test_services/test_sample_service_authorization.py
+++ b/tests/test_services/test_sample_service_authorization.py
@@ -11,6 +11,7 @@ Tests verify:
 3. Users cannot view samples belonging to other users by ID
 4. Sample creation correctly assigns the authenticated user
 """
+
 from datetime import date
 
 import pytest

--- a/tests/test_services/test_sample_service_crud.py
+++ b/tests/test_services/test_sample_service_crud.py
@@ -8,6 +8,7 @@ These tests cover the fundamental CRUD operations for samples:
 - Retrieving samples by ID
 - Handling not found errors appropriately
 """
+
 from datetime import date
 from uuid import uuid4
 

--- a/tests/test_services/test_sample_service_data_isolation.py
+++ b/tests/test_services/test_sample_service_data_isolation.py
@@ -4,6 +4,7 @@ Critical Data Isolation Tests for Clinical Sample Service.
 These tests are CRITICAL for medical data protection - they ensure that users
 can only access their own samples and never see or modify other users' data.
 """
+
 # from uuid import uuid4  # Removed unused import
 
 import pytest

--- a/tests/test_services/test_sample_service_edge_cases_validation.py
+++ b/tests/test_services/test_sample_service_edge_cases_validation.py
@@ -4,6 +4,7 @@ Edge Cases and Validation Tests for Clinical Sample Service.
 These tests focus on input validation, error handling, and edge cases
 to ensure robust and secure operation under various conditions.
 """
+
 from datetime import date, timedelta
 
 # from typing import Any, Dict  # Removed unused import


### PR DESCRIPTION
## Summary
- implement helper builders and response assertions
- add repository tests for user and sample repositories
- cover schema edge cases with new tests
- implement end-to-end workflow integration test
- mark completed tasks in the testing checklist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d17108a5083219ad463accd63d4ec